### PR TITLE
[design]input 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,53 @@
+import { twMerge } from "tailwind-merge";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  className?: string;
+  isValid?: boolean;
+  errorMessage?: string;
+}
+
+export default function Input({
+  label,
+  id,
+  className,
+  isValid,
+  errorMessage,
+  ...props
+}: InputProps) {
+  return (
+    <div className="flex flex-col">
+      <label htmlFor={id} className="body-r text-gray-80 ml-[5px] mb-[2px]">
+        {label}
+      </label>
+      <input
+        id={id}
+        className={twMerge(
+          "w-full h-[38px] rounded-lg input-shadow outline-0 px-3 caption-m placeholder:text-gray-50",
+          !isValid ? "border-[1.5px] border-primary-active" : "",
+          className //사용자 정의 스타일
+        )}
+        {...props} //추가 속성
+      />
+      {!isValid && (
+        <p className="text-functional-danger text-[9px]/[18px] ml-[5px] mt-[2px]">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}
+
+//사용 예시
+{
+  // <Input
+  //   type="text"
+  //   id="nickname"
+  //   label="닉네임"
+  //   placeholder="닉네임을 입력해 주세요"
+  //   value={nickname}
+  //   onChange={(e) => setNickname(e.target.value)}
+  //   isValid={false}
+  //   errorMessage="닉네임 중복"
+  // />
+}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,15 +1,16 @@
 import { twMerge } from "tailwind-merge";
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  label?: string;
+  id: string;
+  label: string;
   className?: string;
   isValid?: boolean;
   errorMessage?: string;
 }
 
 export default function Input({
-  label,
   id,
+  label,
   className,
   isValid = true,
   errorMessage = "",

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -11,7 +11,7 @@ export default function Input({
   label,
   id,
   className,
-  isValid,
+  isValid = true,
   errorMessage,
   ...props
 }: InputProps) {

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -12,7 +12,7 @@ export default function Input({
   id,
   className,
   isValid = true,
-  errorMessage,
+  errorMessage = "",
   ...props
 }: InputProps) {
   return (

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,5 +1,5 @@
 import { twMerge } from "tailwind-merge";
-
+//id, label 필수
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
   label: string;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -17,20 +17,20 @@ export default function Input({
 }: InputProps) {
   return (
     <div className="flex flex-col">
-      <label htmlFor={id} className="body-r text-gray-80 ml-[5px] mb-[2px]">
+      <label htmlFor={id} className="body-r text-gray-80 ml-[5px]">
         {label}
       </label>
       <input
         id={id}
         className={twMerge(
-          "w-full h-[38px] rounded-lg input-shadow outline-0 px-3 caption-m placeholder:text-gray-50",
+          "w-full h-[38px] rounded-lg input-shadow outline-0 px-3 caption-m placeholder:text-gray-50 my-[2px]",
           !isValid ? "border-[1.5px] border-primary-active" : "",
           className //사용자 정의 스타일
         )}
         {...props} //추가 속성
       />
       {!isValid && (
-        <p className="text-functional-danger text-[9px]/[18px] ml-[5px] mt-[2px]">
+        <p className="text-functional-danger text-[9px]/[18px] ml-[5px]">
           {errorMessage}
         </p>
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #8 

## 📝작업 내용

> input 컴포넌트 퍼블리싱
input 컴포넌트가 가질 수 있는 속성 모두 props로 올 수 있도록 했습니다. (placeholder, type 등)
label 이름 설정할 수 있습니다.
사용자 정의 스타일 설정할 수 있습니다.
isValid 를 받지 않았을 경우 기본값 true로 설정했습니다.
isValid가 false 일 경우 기본값 ""로 설정했습니다.
label 없이 사용하는 상황이 없는 것 같아서 label과 id 필수로 설정했습니다.


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/7a11679c-8465-42b5-8e03-6e6295a06ee1)

![image](https://github.com/user-attachments/assets/80467738-c8d1-4b54-bd09-d1719cbd2eb9)

## 💬리뷰 요구사항(선택)
