### PR TITLE
[design] 감정 뱃지 컴포넌트 구현

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -79,7 +79,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "index.html",
-    "revision": "0.77tri5nouc"
+    "revision": "0.97jsgekbb1"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/EmotionBadge.tsx
+++ b/src/components/EmotionBadge.tsx
@@ -1,0 +1,33 @@
+import { EMOTIONS } from "@/constants";
+import { twMerge } from "tailwind-merge";
+
+interface EmotionBadgeProps {
+  size: "small" | "large";
+  emotion: string;
+}
+
+function EmotionBadge({ size, emotion }: EmotionBadgeProps) {
+  // 사이즈별 클래스
+  const sizeClass = {
+    small: "w-[30px] h-[18px] text-[10px] font-bold ",
+    large: "w-[50px] h-[30px] caption-b",
+  };
+
+  // emotion에 해당하는 색상 찾기
+  const emotionData = EMOTIONS.find((e) => e.key === emotion);
+
+  return (
+    <div
+      className={twMerge(
+        "flex items-center justify-center rounded-[50px]",
+        sizeClass[size],
+        emotionData?.bgColor,
+        emotionData?.textColor
+      )}
+    >
+      {emotionData?.label}
+    </div>
+  );
+}
+
+export default EmotionBadge;

--- a/src/constants/emotions.ts
+++ b/src/constants/emotions.ts
@@ -1,10 +1,50 @@
 export const EMOTIONS = [
-  { key: 'HAPPY', label: '행복', color: '#D68EED', background: '#F7DDFF' },
-  { key: 'EXCITED', label: '신남', color: '#CCA929', background: '#FCF1C6' },
-  { key: 'SAD', label: '슬픔', color: '#7E9DC3', background: '#D3E7FF' },
-  { key: 'THRILLED', label: '설렘', color: '#E27F4A', background: '#FFDDCB' },
-  { key: 'CALM', label: '평온', color: '#4DA93A', background: '#C4F0BA' },
-  { key: 'ANNOYED', label: '짜증', color: '#F35356', background: '#FEDADB' },
-  { key: 'UNKNOWN', label: '모름', color: '#399A97', background: '#CCEDEC' },
-  { key: 'WORRIED', label: '걱정', color: '#878787', background: '#E3D6FF' },
+  {
+    key: "HAPPY",
+    label: "행복",
+    textColor: "text-[#D68EED]",
+    bgColor: "bg-[#F7DDFF]",
+  },
+  {
+    key: "EXCITED",
+    label: "신남",
+    textColor: "text-[#CCA929]",
+    bgColor: "bg-[#FCF1C6]",
+  },
+  {
+    key: "SAD",
+    label: "슬픔",
+    textColor: "text-[#7E9DC3]",
+    bgColor: "bg-[#D3E7FF]",
+  },
+  {
+    key: "THRILLED",
+    label: "설렘",
+    textColor: "text-[#E27F4A]",
+    bgColor: "bg-[#FFDDCB]",
+  },
+  {
+    key: "CALM",
+    label: "평온",
+    textColor: "text-[#4DA93A]",
+    bgColor: "bg-[#C4F0BA]",
+  },
+  {
+    key: "ANNOYED",
+    label: "짜증",
+    textColor: "text-[#F35356]",
+    bgColor: "bg-[#FEDADB]",
+  },
+  {
+    key: "UNKNOWN",
+    label: "모름",
+    textColor: "text-[#399A97]",
+    bgColor: "bg-[#CCEDEC]",
+  },
+  {
+    key: "WORRIED",
+    label: "걱정",
+    textColor: "text-[#878787]",
+    bgColor: "bg-[#E3D6FF]",
+  },
 ];


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #7 

## 📝작업 내용

> 감정 상수 tailiwnd로 사용할 수 있게 수정
감정 뱃지 컴포넌트 구현
props로 크기, 감정 값을 전달해주면 사용가능

## 📸 스크린샷
<img width="83" alt="스크린샷 2025-02-18 오전 10 31 25" src="https://github.com/user-attachments/assets/12dfe8b4-6eba-4fca-a1a1-50be3b78b319" />

## 💬리뷰 요구사항(선택)
