### PR TITLE
[feat] 셀렉트 박스 외부 클릭 시 로직

### DIFF
--- a/src/components/MoreOptionsSelect.tsx
+++ b/src/components/MoreOptionsSelect.tsx
@@ -18,7 +18,7 @@ function MoreOptionsSelect({ items }: MoreOptionsSelectProps) {
           <>
             {/* 오버레이 - 전체 화면 덮기 */}
             <div
-              className="fixed inset-0 bg-black/10 z-51"
+              className="fixed inset-0 z-51"
               onClick={() => setIsSelectOpen(false)}
             />
           </>,

--- a/src/components/MoreOptionsSelect.tsx
+++ b/src/components/MoreOptionsSelect.tsx
@@ -1,6 +1,7 @@
 import MoreSelectBox from '@/components/MoreSelectBox';
 import ellipsisIcon from '@assets/icons/ellipsis-icon.svg';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface MoreOptionsSelectProps {
   items: { label: string; onClick: () => void }[];
@@ -8,31 +9,33 @@ interface MoreOptionsSelectProps {
 
 function MoreOptionsSelect({ items }: MoreOptionsSelectProps) {
   const [isSelectOpen, setIsSelectOpen] = useState(false); //셀렉트 박스(드롭다운)의 열림/닫힘 여부를 관리
-  const selectRef = useRef<HTMLDivElement>(null); // 셀렉트 박스 영역 참조
-
-  // 바깥 클릭 감지하여 셀렉트 박스 닫기
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (selectRef.current && !selectRef.current.contains(event.target as Node)) {
-        setIsSelectOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  const isHeader = items.some((item) => item.label === '로그아웃');
 
   return (
-    <div className="relative flex" ref={selectRef}>
+    <div className="relative flex">
+      {isSelectOpen &&
+        createPortal(
+          <>
+            {/* 오버레이 - 전체 화면 덮기 */}
+            <div
+              className="fixed inset-0 bg-black/10 z-51"
+              onClick={() => setIsSelectOpen(false)}
+            />
+          </>,
+          document.body, //Portal을 이용해 body에 추가
+        )}
       <button
         className="px-2 py-3 flex justify-center items-center cursor-pointer"
         onClick={() => setIsSelectOpen((prev) => !prev)}
       >
         <img src={ellipsisIcon} alt="더보기" />
       </button>
-      {isSelectOpen && <MoreSelectBox items={items} />}
+      {isSelectOpen &&
+        (isHeader ? (
+          createPortal(<MoreSelectBox items={items} />, document.body)
+        ) : (
+          <MoreSelectBox items={items} />
+        ))}
     </div>
   );
 }

--- a/src/components/MoreSelectBox.tsx
+++ b/src/components/MoreSelectBox.tsx
@@ -5,8 +5,15 @@ interface MoreSelectBoxProps {
 }
 
 export default function MoreSelectBox({ items }: MoreSelectBoxProps) {
+  const isHeader = items.some((item) => item.label === '로그아웃');
+
   return (
-    <div className="bg-white select-shadow rounded-lg divide-y-[0.5px] divide-gray-10 absolute top-8 right-1 overflow-hidden">
+    <div
+      className={twMerge(
+        'bg-white select-shadow rounded-lg divide-y-[0.5px] divide-gray-10 absolute top-8 overflow-hidden z-52',
+        isHeader ? 'right-4' : 'right-1',
+      )}
+    >
       {items.map(({ label, onClick }) => (
         <button
           key={label}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #11 

## 📝작업 내용

> 셀렉트 박스 외부 클릭 시 셀렉트 박스만 닫히도록 수정했습니다.
셀렉트 박스 열리면 오버레이 추가해서 오버레이 클릭 시 닫히도록 구현했습니다.
header에서 적용 할 경우 문제가 있어서 일단 만약 items에 로그아웃이 있을 경우 header라고 판단하고
header일 경우 추가 처리 했습니다.
이미지는 확인용으로 배경 어둡게  했습니다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/585b91cd-6947-4c0d-85e5-bb84e1c99d4f)
![image](https://github.com/user-attachments/assets/e579fdcf-b9ae-4217-8605-0b90b4a9d885)



## 💬리뷰 요구사항(선택)
