### PR TITLE
[design] 음악 검색 시트 퍼블리싱

### DIFF
--- a/src/components/InfoMessage.tsx
+++ b/src/components/InfoMessage.tsx
@@ -1,0 +1,15 @@
+import logoIcon from '@assets/icons/logo-icon.svg';
+
+// 로고 + text
+function InfoMessage({ text }: { text: string }) {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <div className="flex flex-col items-center gap-2">
+        <img src={logoIcon} alt="로고" className="w-10 h-10" />
+        <span className="text-[14px] font-saeeum">{text}</span>
+      </div>
+    </div>
+  );
+}
+
+export default InfoMessage;

--- a/src/components/MusicSearchList.tsx
+++ b/src/components/MusicSearchList.tsx
@@ -1,0 +1,34 @@
+import Button from '@/components/Button';
+
+interface MusicSearchListProps {
+  albumImage: string; // 앨범이미지
+  songTitle: string; // 노래 제목
+  artistName: string; // 가수
+}
+
+function MusicSearchList({ albumImage, songTitle, artistName }: MusicSearchListProps) {
+  return (
+    <div className="px-3 py-2 flex items-center justify-between bg-white cursor-pointer hover:bg-gray-5">
+      <div className="flex gap-2 items-center">
+        <img src={albumImage} alt="앨범 이미지" className="w-10 h-10 rounded-lg" />
+        <div className="flex flex-col">
+          <span className="body-m">{songTitle}</span>
+          <span className="caption-r text-gray-60">{artistName}</span>
+        </div>
+      </div>
+      <Button className="w-[51px] h-[32px]">선택</Button>
+    </div>
+  );
+}
+
+export default MusicSearchList;
+
+// 사용예시
+
+{
+  /* <MusicSearchList
+  albumImage="https://pbs.twimg.com/media/E68WkI4VIAIW8eT.jpg"
+  songTitle="Hype Boy"
+  artistName="NewJeans"
+/>; */
+}

--- a/src/components/MusicSearchSheet.tsx
+++ b/src/components/MusicSearchSheet.tsx
@@ -1,0 +1,48 @@
+import InfoMessage from '@/components/InfoMessage';
+import MusicSearchList from '@/components/MusicSearchList';
+import SearchBar from '@/components/SearchBar';
+import ModalSheetLayout from '@/layouts/ModalSheetLayout';
+import { useState } from 'react';
+
+function MusicSearchSheet() {
+  const [query, setQuery] = useState(''); // 검색어 상태
+  const [musics, setMusics] = useState([]); // 음악 목록을 저장
+
+  // 음악 리스트 그리는 함수
+  const musicListRender = () => {
+    // ✅ 1. 검색을 수행하지 않은 초기 상태 (query가 비어 있음)
+    if (query === '') {
+      return <InfoMessage text="지금 생각나는 음악이 있나요?" />;
+    }
+
+    // ✅ 2. 검색을 수행했지만 결과가 없는 경우
+    if (musics.length === 0) {
+      return <InfoMessage text="검색 결과가 없습니다" />;
+    }
+
+    // ✅ 3. 검색 결과가 있는 경우, 리스트를 렌더링
+    return (
+      <div className="flex flex-col divide-y divide-gray-5">
+        {musics.map((music, index) => (
+          <MusicSearchList
+            key={index}
+            albumImage="https://pbs.twimg.com/media/E68WkI4VIAIW8eT.jpg"
+            songTitle="Hype Boy"
+            artistName="NewJeans"
+          />
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <ModalSheetLayout>
+      <div className="flex flex-col h-full gap-4 px-3">
+        <SearchBar isSticky />
+        {musicListRender()}
+      </div>
+    </ModalSheetLayout>
+  );
+}
+
+export default MusicSearchSheet;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,10 +2,19 @@ import searchIconDefault from '@assets/icons/search-icon/search-icon-default.svg
 import searchIconHover from '@assets/icons/search-icon/search-icon-hover.svg';
 
 import { useState } from 'react';
-function SearchBar() {
+import { twMerge } from 'tailwind-merge';
+
+// 검색바
+// isSticky를 props로 줄때 검색바 고정
+function SearchBar({ isSticky = false }: { isSticky?: boolean }) {
   const [icon, setIcon] = useState(searchIconDefault); // 아이콘
   return (
-    <div className="w-full h-[38px] rounded-[50px] input-shadow flex items-center px-3 gap-2 focus-within:border-[1.5px] focus-within:border-primary-active">
+    <div
+      className={twMerge(
+        'w-full min-h-[38px] h-[38px] rounded-[50px] input-shadow flex items-center px-3 gap-2 focus-within:border-[1.5px] focus-within:border-primary-active bg-white',
+        isSticky && 'sticky top-[60px]',
+      )}
+    >
       <input
         type="text"
         className="w-full outline-none body-m placeholder:text-gray-400"

--- a/src/layouts/ModalSheetLayout.tsx
+++ b/src/layouts/ModalSheetLayout.tsx
@@ -12,10 +12,10 @@ function ModalSheetLayout({ children, isOwnPost }: ModalSheetLayoutProps) {
     console.log('임시 함수');
   };
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50">
-      <div className="max-w-[600px] w-full h-screen flex flex-col bg-white rounded-[8px] card-shadow">
+    <div className="fixed inset-0 flex items-center justify-center z-50 pb-4">
+      <div className="max-w-[600px] w-full h-screen flex flex-col bg-white rounded-[8px] card-shadow overflow-y-auto">
         {/* 헤더 */}
-        <div className="flex h-[60px] items-center px-4 justify-between">
+        <div className="sticky top-0 flex min-h-[60px] h-[60px] items-center px-4 justify-between bg-white ">
           <button className="w-6 h-6 flex justify-center items-center cursor-pointer">
             <img src={closeIcon} alt="닫기" />
           </button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #51 
## 📝작업 내용
1. 음악 검색 시트 퍼블리싱 진행
2. 검색바 props 받으면 sticky되게 추가하였습니다.

## 📸 스크린샷
<img width="715" alt="스크린샷 2025-02-20 오전 7 46 38" src="https://github.com/user-attachments/assets/e192a3f8-c5fc-4720-8664-ed25375be517" />
<img width="715" alt="스크린샷 2025-02-20 오전 7 48 13" src="https://github.com/user-attachments/assets/18f6ee13-bbef-4bac-b3ac-79f007bf41cf" />
<img width="715" alt="스크린샷 2025-02-20 오전 7 48 33" src="https://github.com/user-attachments/assets/bfd8d089-dd53-4ace-8a49-c1550b1142dd" />


## 💬리뷰 요구사항(선택)
