### PR TITLE
[design] 회원가입 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,7 @@ import ChatConnectLoadingSheet from './components/ChatConnectLoadingSheet';
 import Chat from './pages/chat/Chat';
 import ChatRoom from './pages/chat/ChatRoom';
 import NotFound from './pages/NotFound';
-
-
+import SignUp from '@/pages/signup/SignUp';
 
 function App() {
   return (
@@ -20,6 +19,7 @@ function App() {
           <Route path="/home" element={<Home />} />
           <Route path="/chat" element={<Chat />} />
           <Route path="/chatroom" element={<ChatRoom />} />
+          <Route path="/signup" element={<SignUp />} />
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -39,9 +39,11 @@ export default function InputField({
           </Button>
         )}
       </div>
-      {!isValid && (
-        <p className="text-functional-danger text-[9px]/[18px] ml-[5px]">{errorMessage}</p>
-      )}
+      <div className="flex items-center h-5">
+        {!isValid && (
+          <p className="text-functional-danger text-[9px]/[18px] ml-[5px]">{errorMessage}</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,10 +1,14 @@
 import Header from '@/layouts/header/Header';
 import BottomNav from '@/layouts/BottomNav';
-import { Outlet } from 'react-router';
+import { Outlet, useLocation } from 'react-router';
 import HeaderWithBack from '@/layouts/header/HeaderWithBack';
 import HeaderChat from '@/layouts/header/HeaderChat';
+import { twMerge } from 'tailwind-merge';
 
 function Layout() {
+  const location = useLocation(); // 현재 URL 가져오기
+  const hideBottomNav = location.pathname.includes('signup'); // URL에 "signup" 포함 여부 확인 (임시)
+
   return (
     <div className="relative max-w-[600px] min-w-[320px] w-full min-h-screen mx-auto bg-background flex flex-col">
       {/* 헤더 */}
@@ -12,12 +16,17 @@ function Layout() {
       {/* <HeaderChat showLogo={true} showNickname={true}/> */}
 
       {/* 메인 컨텐츠 영역 */}
-      <div className="pt-[44px] pb-[62px] flex-1 flex justify-center w-full px-3">
+      <div
+        className={twMerge(
+          'pt-[44px] flex-1 flex justify-center w-full px-3',
+          !hideBottomNav && 'pb-[62px] ', // 하단 네비게이션 숨길때만 padding주기
+        )}
+      >
         <Outlet />
       </div>
 
-      {/* 하단 네비게이션 */}
-      <BottomNav />
+      {/* 하단 네비게이션 - signup 페이지가 아닐 때만 렌더링 */}
+      {!hideBottomNav && <BottomNav />}
     </div>
   );
 }

--- a/src/pages/signup/SignUp.tsx
+++ b/src/pages/signup/SignUp.tsx
@@ -1,0 +1,64 @@
+import Button from '@/components/Button';
+import InputField from '@/components/InputField';
+
+function SignUp() {
+  return (
+    <div className=" flex w-full pt-5 pb-[40px] flex-col justify-between">
+      <form className="w-full ">
+        <InputField
+          type="text"
+          id="nickname"
+          label="닉네임"
+          placeholder="닉네임을 입력해 주세요"
+          isValid={false}
+          errorMessage="닉네임 중복"
+          variant="primary"
+          buttonText="중복확인"
+        />
+        <InputField
+          type="password"
+          id="password"
+          label="비밀번호"
+          placeholder="비밀번호를 입력하세요"
+          isValid={false}
+          errorMessage="닉네임 중복"
+        />
+        <InputField
+          type="password"
+          id="passwordConfirm"
+          label="비밀번호 확인"
+          placeholder="비밀번호를 다시 입력하세요"
+          isValid={false}
+          errorMessage="닉네임 중복"
+        />
+        <InputField
+          type="text"
+          id="emailVerification"
+          label="이메일 인증"
+          placeholder="이메일을 입력해 주세요"
+          isValid={false}
+          errorMessage="닉네임 중복"
+          variant="primary"
+          buttonText="인증요청"
+        />
+        {/* 인증번호용 따로 제작해야함 */}
+        <InputField
+          type="text"
+          id="emailVerificationConfrim"
+          label="인증번호 확인"
+          placeholder="이메일을 입력해 주세요"
+          isValid={false}
+          errorMessage="닉네임 중복"
+          variant="primary"
+          buttonText="인증확인"
+        />
+      </form>
+
+      <Button variant="disabled" className="py-[7px] body-m">
+        지금 시작하기
+      </Button>
+    </div>
+  );
+}
+
+export default SignUp;


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #67 

## 📝작업 내용
1. 회원가입 페이지 퍼블리싱
2. 레이아웃에서 하단 네비게이션이 있을때만 패딩을 주도록 하였습니다.
3. 에러메세지 공백 유지할수있게 수정하였습니다.

## 📸 스크린샷
![스크린샷 2025-02-20 오후 12 21 17](https://github.com/user-attachments/assets/665ecb88-163f-4afc-a506-c5dcff32013c)


## 💬리뷰 요구사항(선택)
