### PR TITLE
[design] 페이지에 따른 header, bottom nav 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import Layout from '@/layouts/Layout';
 import Landing from '@/pages/landing/Landing';
-import { Route, Routes } from 'react-router';
+import { Navigate, Route, Routes } from 'react-router';
 import Modal from './components/Modal';
 import Home from '@/pages/home/Home';
 import ChatConnectLoadingSheet from './components/ChatConnectLoadingSheet';
@@ -10,22 +10,27 @@ import NotFound from './pages/NotFound';
 import Login from '@/pages/Login';
 import SignUp from '@/pages/signup/SignUp';
 import UserProfile from '@/pages/userprofile.tsx/UserProfile';
+import PrivateRoute from './routes/PrivateRoute';
 
 function App() {
+  // 실제 로그인 여부를 체크하는 함수 (임시로 false, 실제 인증 로직 적용 필요)
+  const isAuthenticated = true;
   return (
     <>
       <Routes>
         <Route path="/" element={<Layout />}>
-          <Route index element={<Landing />} />
+          <Route index element={isAuthenticated ? <Navigate to="/home" replace /> : <Landing />} />
           {/* test용 */}
-          <Route path="/home" element={<Home />} />
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/chatroom" element={<ChatRoom />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/mypage" element={<UserProfile />} />
-          <Route path="/user/:userId" element={<UserProfile />} />
-
+          {/* PrivateRoute 적용 */}
+          <Route element={<PrivateRoute />}>
+            <Route path="/home" element={<Home />} />
+            <Route path="/chat" element={<Chat />} />
+            <Route path="/chatroom" element={<ChatRoom />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/mypage" element={<UserProfile />} />
+            <Route path="/user/:userId" element={<UserProfile />} />
+          </Route>
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/src/components/MusicAnimation.tsx
+++ b/src/components/MusicAnimation.tsx
@@ -6,7 +6,7 @@ export default function MusicAnimation() {
     <div className="relative w-full mt-[120px] flex items-center justify-center">
       {/* PuffLoader */}
       <div className="absolute z-0">
-        <PuffLoader size={240} color="#EFDAFB" />
+        <PuffLoader size={240} color="#dca4f4" />
       </div>
 
       {/* 배경2*/}

--- a/src/layouts/BottomNav.tsx
+++ b/src/layouts/BottomNav.tsx
@@ -10,7 +10,7 @@ import {
 import { twMerge } from 'tailwind-merge';
 
 const navItems = [
-  { path: '/', label: '홈', icons: { default: homeDefault, active: homeActive } },
+  { path: '/home', label: '홈', icons: { default: homeDefault, active: homeActive } },
   {
     path: '/chat',
     label: '채팅',

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -36,7 +36,7 @@ function Layout() {
       //내 정보 페이지
       location.pathname === '/mypage'
     ) {
-      <Header showMoreOptions showPostButton />;
+      return <Header showMoreOptions showPostButton />;
     } else if (
       //글 작성 페이지
       location.pathname === '/posting' ||

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -7,26 +7,75 @@ import { twMerge } from 'tailwind-merge';
 
 function Layout() {
   const location = useLocation(); // 현재 URL 가져오기
-  const hideBottomNav = location.pathname.includes('signup'); // URL에 "signup" 포함 여부 확인 (임시)
+  //바텀 nav 바 필요한 페이지
+  const showNav =
+    //메인 페이지
+    location.pathname === '/home' ||
+    //마이 페이지
+    location.pathname === '/mypage' ||
+    //유저 페이지
+    location.pathname === '/user' ||
+    //지난 대화 기록 페이지
+    location.pathname === '/chat';
+
+  const renderBottomNav = () => {
+    if (showNav) {
+      return <BottomNav />;
+    } else return null;
+  };
+
+  const renderHeader = () => {
+    if (
+      //메인 페이지
+      location.pathname === '/home' ||
+      //지난 채팅 기록 페이지
+      location.pathname === '/chat'
+    ) {
+      return <Header showPostButton />;
+    } else if (
+      //내 정보 페이지
+      location.pathname === '/mypage'
+    ) {
+      <Header showMoreOptions showPostButton />;
+    } else if (
+      //글 작성 페이지
+      location.pathname === '/posting' ||
+      //회원가입 페이지
+      location.pathname === '/signup' ||
+      //내 정보 수정 페이지
+      location.pathname === '/mypageEdit'
+    ) {
+      return <HeaderWithBack />;
+    } else if (
+      //유저 페이지
+      location.pathname.includes('/user')
+    ) {
+      return <HeaderWithBack showMoreOptions />;
+    } else if (
+      //채팅방 페이지
+      location.pathname.includes('/chatroom')
+    ) {
+      return <HeaderChat showLogo showNickname />;
+    } else return <Header />;
+  };
 
   return (
     <div className="relative max-w-[600px] min-w-[320px] w-full min-h-screen mx-auto bg-background flex flex-col">
       {/* 헤더 */}
-      <Header showMoreOptions />
-      {/* <HeaderChat showLogo={true} showNickname={true}/> */}
+      {renderHeader()}
 
       {/* 메인 컨텐츠 영역 */}
       <div
         className={twMerge(
           'pt-[44px] flex-1 flex justify-center w-full px-3',
-          !hideBottomNav && 'pb-[62px] ', // 하단 네비게이션 숨길때만 padding주기
+          showNav && 'pb-[62px] ', // 하단 네비게이션 숨길때만 padding주기
         )}
       >
         <Outlet />
       </div>
 
-      {/* 하단 네비게이션 - signup 페이지가 아닐 때만 렌더링 */}
-      {!hideBottomNav && <BottomNav />}
+      {/* 하단 네비게이션 */}
+      {renderBottomNav()}
     </div>
   );
 }

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from 'react-router';
+
+// 실제 로그인 여부를 체크하는 함수 (임시로 false, 실제 인증 로직 적용 필요)
+const isAuthenticated = true;
+
+const PrivateRoute = () => {
+  return isAuthenticated ? <Outlet /> : <Navigate to="/" replace />;
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #82 

## 📝작업 내용

> PrivateRoute 추가했습니다. 로그인하지 않았을 경우 랜딩페이지 ('/') 로 리다이렉트 되도록 했습니다.
로그인 했을 경우에 랜딩페이지로 접근할 경우 홈('/home')으로 리다이렉트 되도록 했습니다.
hideBottomNav 로 할 경우 NotFound 페이지에서 bottomnav를 삭제하기 어려워 조건을 반대로 show로 바꿨습니다.
bottomNav에서 홈 링크를 /home 으로 수정했습니다.
location.pathname 은 임시로 설정했고 페이지에 따라 바꾸셔도 됩니다.
적용하면서도 좀 헷갈려서 이상한 부분 있으면 말씀해주세용

## 📸 스크린샷

## 💬리뷰 요구사항(선택)
