### PR TITLE
[design] 포스트 페이지 퍼블리싱 및 자잘한 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ChatRoom from './pages/chat/ChatRoom';
 import NotFound from './pages/NotFound';
 import Login from '@/pages/Login';
 import SignUp from '@/pages/signup/SignUp';
+import Post from '@/pages/post/Post';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
           {/* test용 */}
           <Route path="/home" element={<Home />} />
           <Route path="/chat" element={<Chat />} />
+          <Route path="/post" element={<Post />} />
           <Route path="/chatroom" element={<ChatRoom />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />

--- a/src/components/EmotionBadge.tsx
+++ b/src/components/EmotionBadge.tsx
@@ -4,13 +4,22 @@ import { twMerge } from 'tailwind-merge';
 interface EmotionBadgeProps {
   size: 'small' | 'large';
   emotion: string;
+  isClickable?: boolean; // 클릭 가능 여부
+  onClick?: (emotion: string) => void;
+  className?: string;
 }
 
-function EmotionBadge({ size, emotion }: EmotionBadgeProps) {
+function EmotionBadge({
+  size,
+  emotion,
+  isClickable = false,
+  onClick,
+  className,
+}: EmotionBadgeProps) {
   // 사이즈별 클래스
   const sizeClass = {
-    small: 'w-[30px] h-[18px] text-[10px] font-bold ',
-    large: 'w-[50px] h-[30px] caption-b cursor-pointer',
+    small: 'w-[30px] h-[18px] text-[10px] font-bold',
+    large: 'w-[50px] h-[30px] caption-b',
   };
 
   // emotion에 해당하는 색상 찾기
@@ -23,7 +32,10 @@ function EmotionBadge({ size, emotion }: EmotionBadgeProps) {
         sizeClass[size],
         emotionData?.bgColor,
         emotionData?.textColor,
+        isClickable && 'cursor-pointer', // 클릭 가능할 때만 커서 변경
+        className,
       )}
+      onClick={isClickable && onClick ? () => onClick(emotion) : undefined} // 클릭 가능할 때만 onClick 이벤트 등록
     >
       {emotionData?.label}
     </div>

--- a/src/components/EmotionFilter.tsx
+++ b/src/components/EmotionFilter.tsx
@@ -1,0 +1,28 @@
+import EmotionBadge from '@/components/EmotionBadge';
+import { EMOTIONS } from '@/constants';
+import { twMerge } from 'tailwind-merge';
+
+interface EmotionFilterProps {
+  selectedEmotion: string | null;
+  onEmotionClick: (emotion: string) => void;
+}
+
+export default function EmotionFilter({ selectedEmotion, onEmotionClick }: EmotionFilterProps) {
+  return (
+    <div className="w-fit grid grid-cols-4 gap-y-3 gap-x-5">
+      {EMOTIONS.map((emotion) => (
+        <EmotionBadge
+          key={emotion.key}
+          size="large"
+          emotion={emotion.key}
+          isClickable={true}
+          onClick={onEmotionClick}
+          className={twMerge(
+            'transition-opacity duration-100 hover:opacity-70',
+            selectedEmotion && selectedEmotion !== emotion.key ? 'opacity-40' : 'opacity-100',
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/EmotionFilter.tsx
+++ b/src/components/EmotionFilter.tsx
@@ -9,7 +9,7 @@ interface EmotionFilterProps {
 
 export default function EmotionFilter({ selectedEmotion, onEmotionClick }: EmotionFilterProps) {
   return (
-    <div className="w-fit grid grid-cols-4 gap-y-3 gap-x-5">
+    <div className="w-fit h-fit grid grid-cols-4 gap-y-3 gap-x-5">
       {EMOTIONS.map((emotion) => (
         <EmotionBadge
           key={emotion.key}

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -34,7 +34,7 @@ export default function InputField({
       <div className="flex gap-2">
         <Input id={id} {...props} />
         {variant && (
-          <Button variant={variant} className="w-[65px]" onClick={onClick}>
+          <Button variant={variant} className="w-[65px] flex-shrink-0" onClick={onClick}>
             {buttonText}
           </Button>
         )}

--- a/src/components/YouTubeAudioPlayer.tsx
+++ b/src/components/YouTubeAudioPlayer.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useState } from 'react';
 import YouTube from 'react-youtube';
-import play from '@/assets/icons/play.svg';
+import play from '@/assets/icons/play/play.svg';
 import pause from '@/assets/icons/pause.svg';
-import playCircle from '@/assets/icons/play-circle.svg';
+import playCircle from '@/assets/icons/play/play-circle.svg';
 import pauseCircle from '@/assets/icons/pause-circle.svg';
 import playGray from '@/assets/icons/play-icon-gray.svg';
 import pauseGray from '@/assets/icons/pause-icon-gray.svg';

--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -4,7 +4,7 @@ export const MIN_ID_LENGTH = 5; //아이디 최소 길이
 export const MAX_ID_LENGTH = 20; //아이디 최대 길이
 
 export const MIN_PASSWORD_LENGTH = 8; //비밀번호 최소 길이
-export const MAX_PASSWORD_LENGTH = 32; //비밀번호 최대 길이
+export const MAX_PASSWORD_LENGTH = 16; //비밀번호 최대 길이
 
 export const MAX_CHAT_MESSAGE_LENGTH = 300; //채팅 메시지 최대 길이
 export const MAX_EMOTION_COMMENT_LENGTH = 200; //글 등록 코멘트 최대 길이

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import Button from '@/components/Button';
-import InputField from '@/components/InputField';
 import logo from '@assets/icons/logo.svg';
 import kakao from '@assets/icons/kakao-icon.svg';
 import { Link } from 'react-router';
+import Input from '@/components/Input';
 export default function Login() {
   const handleLogin = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -20,20 +20,25 @@ export default function Login() {
         className="w-full pb-2.5 border-b border-gray-15"
       >
         <div className="flex flex-col gap-2 w-full">
-          <InputField type="text" id="userId" label="아이디" placeholder="아이디를 입력해 주세요" />
-          <InputField
-            type="password"
-            id="userPassword"
-            label="비밀번호"
-            placeholder="비밀번호를 입력해 주세요"
-          />
+          <div>
+            <label htmlFor="userId" className="body-r text-gray-80 ml-[5px] mb-0.5">
+              아이디
+            </label>
+            <Input id="userId" placeholder="아이디를 입력해 주세요" />
+          </div>
+          <div>
+            <label htmlFor="password" className="body-r text-gray-80 ml-[5px] mb-0.5">
+              비밀번호
+            </label>
+            <Input id="password" placeholder="비밀번호를 입력해 주세요" />
+          </div>
         </div>
         <Button className="focus:outline-primary-active mt-[14px]">로그인</Button>
       </form>
 
       <div className="flex flex-col gap-3 items-center w-full mt-2.5 ">
         {/* 소셜 로그인 */}
-        <Button className="bg-[#FFEB3B] text-gray-80 ">
+        <Button className="bg-[#FFEB3B] text-gray-80">
           <img src={kakao} alt="카카오 아이콘" />
           카카오 로그인
         </Button>

--- a/src/pages/chat/components/ChatMusicPlayer.tsx
+++ b/src/pages/chat/components/ChatMusicPlayer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import play from '@/assets/icons/play.svg';
+import play from '@/assets/icons/play/play.svg';
 import defaultImage from '@assets/images/default.png';
 import YouTubeAudioPlayer from '@/components/YouTubeAudioPlayer';
 import { searchYoutubeVideo } from '@/apis/youtube';
@@ -84,7 +84,6 @@ export default function ChatMusicPlayer() {
       <div className="flex w-[calc(100%-28px)]">
         <img src={musicInfo.album_image} alt="album" className="w-[48px] h-[48px]" />
         <div className="relative flex-grow mx-2 overflow-hidden">
-
           <div ref={containerRef} className="w-full">
             <p
               ref={titleRef}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,10 +1,15 @@
-import EmotionBadge from '@/components/EmotionBadge';
-import { EMOTIONS } from '@/constants';
 import SearchBar from '@/components/SearchBar';
-import { twMerge } from 'tailwind-merge';
 import MainCard from '@/components/MainCard';
+import { useState } from 'react';
+import EmotionFilter from '@/components/EmotionFilter';
 
 function Home() {
+  const [selectedEmotion, setSelectedEmotion] = useState<string | null>(null); // 선택된 감정
+  const handleClickedEmotion = (emotion: string) => {
+    setSelectedEmotion((prev) => (prev === emotion ? null : emotion));
+    console.log(emotion);
+  };
+
   return (
     <div className="flex flex-col gap-5 mt-5 h-fit w-full border border-amber-300">
       <SearchBar />
@@ -13,11 +18,7 @@ function Home() {
         <h2 className="font-saeeum text-2xl text-gray-60">
           나와 같은 감정을 느끼는 사람을 찾아보세요
         </h2>
-        <div className="w-fit grid grid-cols-4 gap-y-3 gap-x-5">
-          {EMOTIONS.map((emotion) => (
-            <EmotionBadge size="large" emotion={emotion.key} />
-          ))}
-        </div>
+        <EmotionFilter onEmotionClick={handleClickedEmotion} selectedEmotion={selectedEmotion} />
       </div>
       {/* 메인카드 리스트 */}
       <div className="flex flex-col items-center gap-2.5 pb-5">

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import EmotionFilter from '@/components/EmotionFilter';
 
 function Home() {
   const [selectedEmotion, setSelectedEmotion] = useState<string | null>(null); // 선택된 감정
-  const handleClickedEmotion = (emotion: string) => {
+  const onEmotionClick = (emotion: string) => {
     setSelectedEmotion((prev) => (prev === emotion ? null : emotion));
     console.log(emotion);
   };
@@ -18,7 +18,7 @@ function Home() {
         <h2 className="font-saeeum text-2xl text-gray-60">
           나와 같은 감정을 느끼는 사람을 찾아보세요
         </h2>
-        <EmotionFilter onEmotionClick={handleClickedEmotion} selectedEmotion={selectedEmotion} />
+        <EmotionFilter onEmotionClick={onEmotionClick} selectedEmotion={selectedEmotion} />
       </div>
       {/* 메인카드 리스트 */}
       <div className="flex flex-col items-center gap-2.5 pb-5">

--- a/src/pages/post/Post.tsx
+++ b/src/pages/post/Post.tsx
@@ -1,0 +1,45 @@
+import Button from '@/components/Button';
+import EmotionFilter from '@/components/EmotionFilter';
+import MusicCard from '@/components/MusicCard';
+import Comment from '@/pages/post/components/Comment';
+import { useState } from 'react';
+
+export default function Post() {
+  const [selectedEmotion, setSelectedEmotion] = useState<string | null>(null); // 선택된 감정
+  const [comment, setComment] = useState<string>(''); // 코멘트
+
+  // 감정 선택 시
+  const onEmotionClick = (emotion: string) => {
+    setSelectedEmotion((prev) => (prev === emotion ? null : emotion));
+    console.log(emotion);
+  };
+
+  // 코멘트 입력 시
+  const onChangeComment = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(e.target.value);
+  };
+
+  return (
+    <div className="flex flex-col w-full items-center justify-between pb-10">
+      <div className="flex flex-col items-center mt-5 gap-6 w-fit">
+        {/* 감정 선택 */}
+        <div className="flex flex-col items-center gap-5">
+          <h2 className="font-saeeum text-2xl text-gray-60">이 순간, 어떤 감정이 떠오르나요?</h2>
+          <EmotionFilter onEmotionClick={onEmotionClick} selectedEmotion={selectedEmotion} />
+        </div>
+
+        {/* 음악 검색 */}
+        <MusicCard />
+
+        {/* 사용자 코멘트 */}
+        <Comment
+          selectedEmotion={selectedEmotion}
+          comment={comment}
+          onChangeComment={onChangeComment}
+        />
+      </div>
+      {/* 버튼 */}
+      <Button>기록 완료</Button>
+    </div>
+  );
+}

--- a/src/pages/post/components/Comment.tsx
+++ b/src/pages/post/components/Comment.tsx
@@ -1,0 +1,42 @@
+import EmotionBadge from '@/components/EmotionBadge';
+import { MAX_EMOTION_COMMENT_LENGTH } from '@/constants';
+
+interface CommentProps {
+  selectedEmotion: string | null; // 선택된 감정
+  onChangeComment: (e: React.ChangeEvent<HTMLTextAreaElement>) => void; // 코멘트 입력시
+  comment: string; // 코멘트
+}
+
+export default function Comment({ selectedEmotion, onChangeComment, comment }: CommentProps) {
+  return (
+    <div className="flex flex-col w-full gap-1">
+      {/* 상태 */}
+      <label htmlFor="userComment" className="flex items-center gap-2 ml-1 body-m">
+        <span className="font-saeeum text-xl text-gray-60"> 나는 지금</span>
+        {selectedEmotion ? (
+          <EmotionBadge size="small" emotion={selectedEmotion} />
+        ) : (
+          <span className="font-saeeum text-xl text-gray-60">💭</span>
+        )}
+      </label>
+      {/* 코멘트 입력 */}
+      <div className="flex flex-col w-full gap-1">
+        {/* 입력창 */}
+        <div className="h-24 bg-white drop-shadow rounded-lg body-r overflow-hidden px-2 py-3">
+          <textarea
+            name="comment"
+            id="userComment"
+            placeholder="지금 떠오르는 생각을 자유롭게 적어보세요"
+            className="scroll resize-none w-full h-full m-1 break-words"
+            onChange={(e) => onChangeComment(e)}
+            maxLength={MAX_EMOTION_COMMENT_LENGTH}
+          ></textarea>
+        </div>
+        {/* 글자수 최대 200 */}
+        <span className="self-end caption-r text-gray-50 mr-1">
+          {comment?.length}/{MAX_EMOTION_COMMENT_LENGTH}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,4 @@
 @import '@styles/tailwind.css';
 @import '@styles/fonts.css';
 @import '@styles/typography.css';
+@import '@styles/scrollbar.css';

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -1,0 +1,16 @@
+/* 스크롤바 설정 */
+.scroll::-webkit-scrollbar {
+  width: 10px; /* 스크롤바 너비 */
+}
+
+/* 스크롤바 막대 (thumb) */
+.scroll::-webkit-scrollbar-thumb {
+  background-color: rgb(236, 236, 236); /* 스크롤바를 흰색으로 */
+  border-radius: 10px; /* 둥글게 */
+  border: 4px solid rgb(236, 236, 236); /* 배경색과 같은 테두리 추가 */
+}
+
+/* 스크롤바 배경 (track) */
+.scroll::-webkit-scrollbar-track {
+  background-color: rgba(0, 0, 0, 0); /* 투명 */
+}

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,6 +1,11 @@
 @layer base {
+  *:focus {
+    outline: none;
+  }
+
   body {
     font-family: var(--font-pretendard);
+    font-synthesis: none;
     @apply text-gray-80;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #62 

## 📝작업 내용
1. EmotionBadge 수정
> 프롭스로 클릭 가능 여부랑 onClick 함수 전달 받을 수 있도록 수정했습니다
2. InputField flex-shrink-0 추가
> 버튼 컴포넌트 너비가 줄어들어서 추가했습니다
3. 상수 비밀번호 최대 길이 32 → 16 변경 (백엔드 분들에게도 전달해야 합니다!)
4. Login 페이지 InputField → Input 컴포넌트 사용 변경
5. Post 페이지 추가
6. EmotionFilter 컴포넌트 추가
7. Home 감정 필터링 컴포넌트로 변경
8. scrollbar.css 추가
> 기본 스크롤이 안에 들어가니까 안 예뻐서 수정했어요! 최대한 기본 스크롤과 차이가 없도록 했습니다
클래스명에 `scroll` 추가하면 적용됩니당

변경 전
![image](https://github.com/user-attachments/assets/c523a4ff-a72f-4017-9471-6ffdd50775c6)

변경 후
![image](https://github.com/user-attachments/assets/52d5a7c2-95ee-49c7-a0bd-f788c5a6d3b3)

9. 포커스 아웃라인 none 추가
> 개별로 안 줘도 됩니다!
```jsx
*:focus {
    outline: none;
  }
```

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/991e64f5-8ffc-4a37-95e2-d537f395f759)


## 💬리뷰 요구사항(선택)
