### PR TITLE
[feat] 음악 검색 api 연결 + 무한 스크롤 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,15 @@ import Post from '@/pages/post/Post';
 import UserProfile from '@/pages/userprofile.tsx/UserProfile';
 import PrivateRoute from './routes/PrivateRoute';
 import EditProfile from '@/pages/editprofile/EditProfile';
+import { useSpotifyAuth } from './hooks/useSpotifyAuth';
 
 function App() {
   // 실제 로그인 여부를 체크하는 함수 (임시로 false, 실제 인증 로직 적용 필요)
   const isAuthenticated = true;
+  // soundlink 로그인한 경우에만 spotify 로그인 후 토큰 가져오기
+  if (isAuthenticated) {
+    useSpotifyAuth();
+  }
   return (
     <>
       <Routes>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -6,13 +6,13 @@ import { twMerge } from 'tailwind-merge';
 
 interface SearchBarProps {
   isSticky?: boolean;
-  query: string;
-  setQuery: (query: string) => void;
+  searchText: string;
+  setSearchText: (query: string) => void;
 }
 
 // 검색바
 // isSticky를 props로 줄때 검색바 고정
-function SearchBar({ isSticky = false, query, setQuery }: SearchBarProps) {
+function SearchBar({ isSticky = false, searchText, setSearchText }: SearchBarProps) {
   const [icon, setIcon] = useState(searchIconDefault); // 아이콘
   return (
     <div
@@ -25,8 +25,8 @@ function SearchBar({ isSticky = false, query, setQuery }: SearchBarProps) {
         type="text"
         className="w-full outline-none body-m placeholder:text-gray-400"
         placeholder="오늘의 음악을 검색해 보세요"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
       />
       <button
         className="cursor-pointer"

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,9 +4,15 @@ import searchIconHover from '@assets/icons/search-icon/search-icon-hover.svg';
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
+interface SearchBarProps {
+  isSticky?: boolean;
+  query: string;
+  setQuery: (query: string) => void;
+}
+
 // 검색바
 // isSticky를 props로 줄때 검색바 고정
-function SearchBar({ isSticky = false }: { isSticky?: boolean }) {
+function SearchBar({ isSticky = false, query, setQuery }: SearchBarProps) {
   const [icon, setIcon] = useState(searchIconDefault); // 아이콘
   return (
     <div
@@ -19,6 +25,8 @@ function SearchBar({ isSticky = false }: { isSticky?: boolean }) {
         type="text"
         className="w-full outline-none body-m placeholder:text-gray-400"
         placeholder="오늘의 음악을 검색해 보세요"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
       />
       <button
         className="cursor-pointer"

--- a/src/components/modalSheet/MusicSearchSheet.tsx
+++ b/src/components/modalSheet/MusicSearchSheet.tsx
@@ -1,7 +1,6 @@
 import InfoMessage from '@/components/InfoMessage';
 import MusicSearchList from '@/components/modalSheet/MusicSearchList';
 import SearchBar from '@/components/SearchBar';
-import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
 import ModalSheetLayout from '@/layouts/ModalSheetLayout';
 import { useEffect, useRef, useState } from 'react';
 import defaultImage from '@assets/images/default.png';
@@ -11,8 +10,8 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 function MusicSearchSheet() {
   const [searchText, setSearchText] = useState('');
   const [query, setQuery] = useState('');
-  //spotify 로그인 후 토큰 가져오기
-  const { token } = useSpotifyAuth();
+  //로컬 스토리지에서 토큰 가져오기
+  const spotifyAccessToken = localStorage.getItem('spotify_access_token');
 
   // 무한 스크롤 감지용 ref
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -23,7 +22,7 @@ function MusicSearchSheet() {
       `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&offset=${pageParam}`,
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${spotifyAccessToken}`,
         },
       },
     );
@@ -32,8 +31,8 @@ function MusicSearchSheet() {
 
   const {
     data, // 가져온 데이터
-    isLoading, // 첫 페이지 로딩 중
-    isFetchingNextPage, // 다음 페이지 로딩 중
+    // isLoading, // 첫 페이지 로딩 중
+    // isFetchingNextPage, // 다음 페이지 로딩 중
     hasNextPage, // 다음 페이지 여부
     fetchNextPage, // 다음 페이지 요청 함수
   } = useInfiniteQuery({
@@ -82,6 +81,9 @@ function MusicSearchSheet() {
 
   //음악 리스트 렌더링
   const musicListRender = () => {
+    if (!spotifyAccessToken) {
+      return <InfoMessage text="Spotify 로그인이 필요합니다." />;
+    }
     if (!query) {
       return <InfoMessage text="지금 생각나는 음악이 있나요?" />;
     }

--- a/src/components/modalSheet/MusicSearchSheet.tsx
+++ b/src/components/modalSheet/MusicSearchSheet.tsx
@@ -1,12 +1,77 @@
 import InfoMessage from '@/components/InfoMessage';
 import MusicSearchList from '@/components/modalSheet/MusicSearchList';
 import SearchBar from '@/components/SearchBar';
+import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
 import ModalSheetLayout from '@/layouts/ModalSheetLayout';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import defaultImage from '@assets/images/default.png';
+
+interface SpotifyMusic {
+  album: {
+    album_type: string;
+    artists: SpotifyArtist[];
+    available_markets: string[];
+    external_urls: { spotify: string };
+    href: string;
+    id: string;
+    images?: { url: string; height: number; width: number }[];
+    name: string;
+    release_date?: string;
+    release_date_precision?: string;
+    total_tracks?: number;
+    type: string;
+    uri: string;
+  };
+  artists: SpotifyArtist[];
+  available_markets: string[];
+  disc_number: number;
+  duration_ms: number;
+  explicit: boolean;
+  external_ids: { isrc: string };
+  external_urls: { spotify: string };
+  href: string;
+  id: string;
+  is_local: boolean;
+  is_playable: boolean;
+  name: string;
+  popularity: number;
+  preview_url: string | null;
+  track_number: number;
+  type: string;
+  uri: string;
+}
+
+interface SpotifyArtist {
+  external_urls: { spotify: string };
+  href: string;
+  id: string;
+  name: string;
+  type: string;
+  uri: string;
+}
 
 function MusicSearchSheet() {
   const [query, setQuery] = useState(''); // 검색어 상태
-  const [musics, setMusics] = useState([]); // 음악 목록을 저장
+  const [musics, setMusics] = useState<SpotifyMusic[]>([]); // 음악 목록을 저장
+
+  const { token } = useSpotifyAuth();
+
+  // spotify 음악 검색
+  const searchMusic = async (query: string) => {
+    const res = await fetch(
+      `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    const data = await res.json();
+    if (data.tracks.items.length > 0) {
+      console.log(data.tracks.items);
+      setMusics(data.tracks.items); // 검색된 트랙들 저장
+    } else {
+      setMusics([]); // 검색 결과가 없으면 빈 배열
+    }
+  };
 
   // 음악 리스트 그리는 함수
   const musicListRender = () => {
@@ -26,19 +91,31 @@ function MusicSearchSheet() {
         {musics.map((music, index) => (
           <MusicSearchList
             key={index}
-            albumImage="https://pbs.twimg.com/media/E68WkI4VIAIW8eT.jpg"
-            songTitle="Hype Boy"
-            artistName="NewJeans"
+            albumImage={music.album.images?.[0]?.url || defaultImage}
+            songTitle={music.name}
+            artistName={music.artists[0].name}
           />
         ))}
       </div>
     );
   };
 
+  useEffect(() => {
+    if (query === '') {
+      setMusics([]);
+      return;
+    }
+    const debounce = setTimeout(() => {
+      if (query.trim()) searchMusic(query);
+    }, 300); // 디바운스
+
+    return () => clearTimeout(debounce);
+  }, [query]);
+
   return (
     <ModalSheetLayout>
       <div className="flex flex-col h-full gap-4 px-3">
-        <SearchBar isSticky />
+        <SearchBar isSticky query={query} setQuery={setQuery} />
         {musicListRender()}
       </div>
     </ModalSheetLayout>

--- a/src/components/modalSheet/MusicSearchSheet.tsx
+++ b/src/components/modalSheet/MusicSearchSheet.tsx
@@ -3,120 +3,117 @@ import MusicSearchList from '@/components/modalSheet/MusicSearchList';
 import SearchBar from '@/components/SearchBar';
 import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
 import ModalSheetLayout from '@/layouts/ModalSheetLayout';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import defaultImage from '@assets/images/default.png';
-
-interface SpotifyMusic {
-  album: {
-    album_type: string;
-    artists: SpotifyArtist[];
-    available_markets: string[];
-    external_urls: { spotify: string };
-    href: string;
-    id: string;
-    images?: { url: string; height: number; width: number }[];
-    name: string;
-    release_date?: string;
-    release_date_precision?: string;
-    total_tracks?: number;
-    type: string;
-    uri: string;
-  };
-  artists: SpotifyArtist[];
-  available_markets: string[];
-  disc_number: number;
-  duration_ms: number;
-  explicit: boolean;
-  external_ids: { isrc: string };
-  external_urls: { spotify: string };
-  href: string;
-  id: string;
-  is_local: boolean;
-  is_playable: boolean;
-  name: string;
-  popularity: number;
-  preview_url: string | null;
-  track_number: number;
-  type: string;
-  uri: string;
-}
-
-interface SpotifyArtist {
-  external_urls: { spotify: string };
-  href: string;
-  id: string;
-  name: string;
-  type: string;
-  uri: string;
-}
+import axios from 'axios';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 function MusicSearchSheet() {
-  const [query, setQuery] = useState(''); // 검색어 상태
-  const [musics, setMusics] = useState<SpotifyMusic[]>([]); // 음악 목록을 저장
-
+  const [searchText, setSearchText] = useState('');
+  const [query, setQuery] = useState('');
+  //spotify 로그인 후 토큰 가져오기
   const { token } = useSpotifyAuth();
 
-  // spotify 음악 검색
-  const searchMusic = async (query: string) => {
-    const res = await fetch(
-      `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track`,
+  // 무한 스크롤 감지용 ref
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  //Spotify 음악 검색
+  const fetchMusic = async ({ pageParam = 0 }) => {
+    const { data } = await axios.get(
+      `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&offset=${pageParam}`,
       {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       },
     );
-    const data = await res.json();
-    if (data.tracks.items.length > 0) {
-      console.log(data.tracks.items);
-      setMusics(data.tracks.items); // 검색된 트랙들 저장
-    } else {
-      setMusics([]); // 검색 결과가 없으면 빈 배열
-    }
+    return { items: data.tracks.items, total: data.tracks.total };
   };
 
-  // 음악 리스트 그리는 함수
+  const {
+    data, // 가져온 데이터
+    isLoading, // 첫 페이지 로딩 중
+    isFetchingNextPage, // 다음 페이지 로딩 중
+    hasNextPage, // 다음 페이지 여부
+    fetchNextPage, // 다음 페이지 요청 함수
+  } = useInfiniteQuery({
+    queryKey: ['musics', query], // 검색어를 쿼리 키로 사용
+    queryFn: fetchMusic,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const nextOffset = allPages.length * 20;
+      return nextOffset < lastPage.total ? nextOffset : undefined;
+    },
+    enabled: !!query, // 검색어가 있을 때만 API 호출
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
+  });
+
+  //디바운스 적용
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (searchText.trim()) {
+        setQuery(searchText);
+      } else {
+        setQuery('');
+      }
+    }, 300);
+
+    return () => clearTimeout(handler);
+  }, [searchText]);
+
+  //무한스크롤 IO
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasNextPage) {
+        fetchNextPage(); // 하단에 도달하면 다음 페이지를 요청
+      }
+    });
+
+    if (loadMoreRef.current) {
+      observer.observe(loadMoreRef.current);
+    }
+
+    return () => {
+      if (loadMoreRef.current) {
+        observer.unobserve(loadMoreRef.current);
+      }
+    };
+  }, [hasNextPage, fetchNextPage]);
+
+  //음악 리스트 렌더링
   const musicListRender = () => {
-    // ✅ 1. 검색을 수행하지 않은 초기 상태 (query가 비어 있음)
-    if (query === '') {
+    if (!query) {
       return <InfoMessage text="지금 생각나는 음악이 있나요?" />;
     }
 
-    // ✅ 2. 검색을 수행했지만 결과가 없는 경우
-    if (musics.length === 0) {
+    if (!data?.pages[0].items.length) {
       return <InfoMessage text="검색 결과가 없습니다" />;
     }
 
-    // ✅ 3. 검색 결과가 있는 경우, 리스트를 렌더링
     return (
       <div className="flex flex-col divide-y divide-gray-5">
-        {musics.map((music, index) => (
-          <MusicSearchList
-            key={index}
-            albumImage={music.album.images?.[0]?.url || defaultImage}
-            songTitle={music.name}
-            artistName={music.artists[0].name}
-          />
+        {data?.pages.map((page, index) => (
+          <div key={index}>
+            {page.items.map((music: SpotifyMusic, i: number) => (
+              <MusicSearchList
+                key={i}
+                albumImage={music.album.images?.[0]?.url || defaultImage}
+                songTitle={music.name}
+                artistName={music.artists[0].name}
+              />
+            ))}
+          </div>
         ))}
       </div>
     );
   };
 
-  useEffect(() => {
-    if (query === '') {
-      setMusics([]);
-      return;
-    }
-    const debounce = setTimeout(() => {
-      if (query.trim()) searchMusic(query);
-    }, 300); // 디바운스
-
-    return () => clearTimeout(debounce);
-  }, [query]);
-
   return (
     <ModalSheetLayout>
       <div className="flex flex-col h-full gap-4 px-3">
-        <SearchBar isSticky query={query} setQuery={setQuery} />
+        <SearchBar isSticky searchText={searchText} setSearchText={setSearchText} />
         {musicListRender()}
+        <div ref={loadMoreRef} className="min-h-[10px]"></div>
       </div>
     </ModalSheetLayout>
   );

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+const CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.VITE_SPOTIFY_REDIRECT_URI;
+const AUTH_URL = "https://accounts.spotify.com/authorize";
+
+// useSpotifyAuth 훅 (로그인 및 토큰 관리)
+export const useSpotifyAuth = () => {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const hash = new URLSearchParams(window.location.hash.substring(1));
+    const accessToken = hash.get("access_token");
+    const expiresIn = hash.get("expires_in");
+
+    if (accessToken && expiresIn) {
+      const expiresAt = Date.now() + Number(expiresIn) * 1000; // 현재 시간 + 만료 시간(ms)
+      localStorage.setItem("spotify_access_token", accessToken);
+      localStorage.setItem("spotify_expires_at", expiresAt.toString());
+      setToken(accessToken);
+      window.history.pushState({}, document.title, window.location.pathname);
+    } else {
+      checkTokenValidity();
+    }
+  }, []);
+
+  //토큰 유효성 검사
+  const checkTokenValidity = () => {
+    const storedToken = localStorage.getItem("spotify_access_token");
+    const expiresAt = localStorage.getItem("spotify_expires_at");
+
+    if (!storedToken || !expiresAt || Date.now() > Number(expiresAt)) {
+      login();
+    } else {
+      setToken(storedToken);
+    }
+  };
+
+  //로그인
+  const login = () => {
+    const scope = "streaming user-read-playback-state user-modify-playback-state";
+    const url = `${AUTH_URL}?client_id=${CLIENT_ID}&response_type=token&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=${encodeURIComponent(scope)}`;
+    window.location.href = url;
+  };
+
+  return { token };
+};

--- a/src/types/spotify.d.ts
+++ b/src/types/spotify.d.ts
@@ -1,0 +1,43 @@
+interface SpotifyMusic {
+    album: {
+      album_type: string;
+      artists: SpotifyArtist[];
+      available_markets: string[];
+      external_urls: { spotify: string };
+      href: string;
+      id: string;
+      images?: { url: string; height: number; width: number }[];
+      name: string;
+      release_date?: string;
+      release_date_precision?: string;
+      total_tracks?: number;
+      type: string;
+      uri: string;
+    };
+    artists: SpotifyArtist[];
+    available_markets: string[];
+    disc_number: number;
+    duration_ms: number;
+    explicit: boolean;
+    external_ids: { isrc: string };
+    external_urls: { spotify: string };
+    href: string;
+    id: string;
+    is_local: boolean;
+    is_playable: boolean;
+    name: string;
+    popularity: number;
+    preview_url: string | null;
+    track_number: number;
+    type: string;
+    uri: string;
+  }
+  
+  interface SpotifyArtist {
+    external_urls: { spotify: string };
+    href: string;
+    id: string;
+    name: string;
+    type: string;
+    uri: string;
+  }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #90 
## 📝작업 내용

> 음악 검색 api 연결
무한 스크롤 구현
+ soundlink 로그인 한 경우에만 spotify 로그인 하도록 임시로 수정했습니다.

## 📸 스크린샷
검색바 뒤에 검색 내용 보이는 것 수정 필요
![image](https://github.com/user-attachments/assets/f72e63b1-0a30-4081-8261-f442f93a911f)

![image](https://github.com/user-attachments/assets/91da9d68-1c57-41c2-afdf-90c75f86b744)
![image](https://github.com/user-attachments/assets/cc94812b-0d5e-4c4c-a636-cca123852c22)
![image](https://github.com/user-attachments/assets/3b8050de-3486-4278-85f7-e73a03a1edaf)


## 💬리뷰 요구사항(선택)
