### PR TITLE
[feat] 버튼 로딩, 애니메이션, 모달과 시트 오픈 시 스크롤, 모달 overlay 수정, youtube portal로 이동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,9 +57,9 @@ function App() {
       location.pathname === '/mypage/blocklist'
     ) {
       return {
-        initial: { x: '80%' },
+        initial: { x: '100%' },
         animate: { x: 0 },
-        exit: { x: '80%' },
+        exit: { x: '100%' },
         transition: { duration: 0.3 },
         style: { zIndex: 1 },
       };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useAuthStore } from '@/store/authStore';
-import { Navigate, Route, Routes } from 'react-router';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import Layout from '@/layouts/Layout';
 import Landing from '@/pages/landing/Landing';
 import Modal from '@/components/Modal';
@@ -23,8 +23,11 @@ import YouTubeAudioPlayer from './components/YouTubeAudioPlayer';
 
 // TODO: 테스트용 나중에 지우기
 import TestLoginModal from '@/components/testLogin/TestLoginModal';
+import { AnimatePresence, motion } from 'framer-motion';
+import { twMerge } from 'tailwind-merge';
 
 function App() {
+  const location = useLocation();
   // 실제 로그인 여부를 체크하는 함수 (임시로 false, 실제 인증 로직 적용 필요)
   // const isAuthenticated = true;
   const { isAuthenticated } = useAuthStore();
@@ -44,38 +47,85 @@ function App() {
       setApiReady();
     }); // 앱이 처음 실행될 때 API 로드
   }, []);
+
+  const getAnimation = () => {
+    // location.pathname 등으로 분기하여 애니메이션 설정 반환
+    if (
+      location.pathname === '/signup' ||
+      location.pathname === '/post' ||
+      location.pathname === '/mypage/edit' ||
+      location.pathname === '/mypage/blocklist'
+    ) {
+      return {
+        initial: { x: '80%' },
+        animate: { x: 0 },
+        exit: { x: '80%' },
+        transition: { duration: 0.3 },
+        style: { zIndex: 1 },
+      };
+    } else {
+      // 기본 애니메이션 설정
+      return {
+        initial: { opacity: 0 },
+        animate: { opacity: 1 },
+        exit: { opacity: 0 },
+        transition: { duration: 0.3 },
+      };
+    }
+  };
+
   return (
     <>
       {/* 테스트용 나중에 지우기 */}
       <TestLoginModal />
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={isAuthenticated ? <Navigate to="/home" replace /> : <Landing />} />
+      <AnimatePresence mode="sync">
+        <motion.div
+          key={location.pathname}
+          {...getAnimation()}
+          className={twMerge('absolute left-1/2 -translate-x-1/2 w-full max-w-[600px] z-10')}
+        >
+          <Routes location={location}>
+            <Route path="/" element={<Layout />}>
+              <Route
+                index
+                element={isAuthenticated ? <Navigate to="/home" replace /> : <Landing />}
+              />
 
-          <Route
-            path="/login"
-            element={isAuthenticated ? <Navigate to="/home" replace /> : <Login />}
-          />
-          <Route
-            path="/signup"
-            element={isAuthenticated ? <Navigate to="/home" replace /> : <SignUp />}
-          />
+              <Route
+                path="/login"
+                element={isAuthenticated ? <Navigate to="/home" replace /> : <Login />}
+              />
+              <Route
+                path="/signup"
+                element={isAuthenticated ? <Navigate to="/home" replace /> : <SignUp />}
+              />
 
-          {/* test용 */}
-          {/* PrivateRoute 적용 */}
-          <Route element={<PrivateRoute />}>
-            <Route path="/home" element={<Home />} />
-            <Route path="/chat" element={<Chat />} />
-            <Route path="/post" element={<Post />} />
-            <Route path="/chatroom" element={<ChatRoom />} />
-            <Route path="/mypage" element={<UserProfile isMyPage={true} />} />
-            <Route path="/mypage/edit" element={<EditProfile />} />
-            <Route path="/mypage/blocklist" element={<BlockList />} />
-            <Route path="/user/:userId" element={<UserProfile isMyPage={false} />} />
-          </Route>
-          <Route path="*" element={<NotFound />} />
-        </Route>
-      </Routes>
+              {/* test용 */}
+              {/* PrivateRoute 적용 */}
+              <Route element={<PrivateRoute />}>
+                <Route path="/home" element={<Home />} />
+                <Route path="/chat" element={<Chat />} />
+                <Route path="/post" element={<Post />} />
+                <Route path="/chatroom" element={<ChatRoom />} />
+                <Route path="/mypage" element={<UserProfile isMyPage={true} />} />
+                <Route path="/mypage/edit" element={<EditProfile />} />
+                <Route path="/mypage/blocklist" element={<BlockList />} />
+                <Route path="/user/:userId" element={<UserProfile isMyPage={false} />} />
+              </Route>
+              <Route path="*" element={<NotFound />} />
+            </Route>
+          </Routes>
+        </motion.div>
+      </AnimatePresence>
+      {/* 양옆에 배경을 만드는 Grid 컨테이너 */}
+      <div className="absolute top-0 left-0 right-0 bottom-0 grid grid-cols-[1fr_auto_1fr]">
+        {/* 왼쪽 배경 */}
+        <div className="w-full h-full bg-white z-50"></div>
+        {/* 실제 내용이 들어가는 부분 */}
+        <div className="relative w-[600px]"></div>
+        {/* 오른쪽 배경 */}
+        <div className="w-full h-full bg-white z-50"></div>
+      </div>
       <Modal />
       <ChatConnectLoadingSheet />
       <YouTubeAudioPlayer playerId="1" />

--- a/src/components/InputAuthCode.tsx
+++ b/src/components/InputAuthCode.tsx
@@ -19,7 +19,7 @@ interface InputAuthCodeProps extends React.InputHTMLAttributes<HTMLInputElement>
   resendCount: number; // 재전송 횟수
 
   // ✅ 버튼 관련 속성 추가
-  buttonText: string;
+  buttonText: string | React.ReactNode;
   variant: 'primary' | 'secondary' | 'disabled';
   onClick: () => void;
   onButtonClick?: () => void;

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -15,7 +15,7 @@ interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   validationMessages?: ValidationMessage; // 띄울 메세지
 }
 interface ButtonProps {
-  buttonText?: string;
+  buttonText?: string | React.ReactNode;
   variant?: 'primary' | 'secondary' | 'disabled';
   onClick?: () => void;
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -9,7 +9,7 @@ export default function Modal() {
   return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={closeModal}
+      // onClick={closeModal}
     >
       <div
         className="bg-white p-5 mx-5 rounded-lg card-shadow w-[287px] min-h-[148px] flex flex-col justify-between"

--- a/src/components/MoreOptionsSelect.tsx
+++ b/src/components/MoreOptionsSelect.tsx
@@ -1,5 +1,6 @@
 import MoreSelectBox from '@/components/MoreSelectBox';
 import ellipsisIcon from '@assets/icons/ellipsis-icon.svg';
+import { AnimatePresence } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 
 interface MoreOptionsSelectProps {
@@ -32,7 +33,8 @@ function MoreOptionsSelect({ items }: MoreOptionsSelectProps) {
       >
         <img src={ellipsisIcon} alt="더보기" />
       </button>
-      {isSelectOpen && <MoreSelectBox items={items} />}
+      {/* 사라질 때 애니메이션 적용 */}
+      <AnimatePresence>{isSelectOpen && <MoreSelectBox items={items} />}</AnimatePresence>
     </div>
   );
 }

--- a/src/components/MoreSelectBox.tsx
+++ b/src/components/MoreSelectBox.tsx
@@ -1,4 +1,5 @@
 import { twMerge } from 'tailwind-merge';
+import { motion } from 'framer-motion';
 
 interface MoreSelectBoxProps {
   items: { label: string; onClick?: () => void }[];
@@ -6,18 +7,26 @@ interface MoreSelectBoxProps {
 
 export default function MoreSelectBox({ items }: MoreSelectBoxProps) {
   return (
-    <div className="bg-white select-shadow rounded-lg divide-y-[0.5px] divide-gray-10 absolute top-8 right-1 overflow-hidden">
-      {items.map(({ label, onClick }) => (
-        <button
-          key={label}
-          className={twMerge(
-            'flex justify-center items-center w-full h-[38px] body-m cursor-pointer transition-all whitespace-nowrap px-5 hover:bg-secondary-1 hover:text-primary-active',
-          )}
-          onClick={onClick}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
+      <motion.div
+        key="more-select-box"
+        className="bg-white select-shadow rounded-lg divide-y-[0.5px] divide-gray-10 absolute top-8 right-1 overflow-hidden"
+        initial={{ scale: 0.5, opacity: 0 }} // 초기 상태: 투명도 0, 위쪽으로 이동
+        animate={{ scale: 1, opacity: 1 }} // 애니메이션: 투명도 1, 원래 위치로
+        transition={{ duration: 0.1, ease: 'easeOut' }} // 애니메이션 시간
+        style={{ originX: 1, originY: 0 }}
+        exit={{ scale: 0.5, opacity: 0 }}
+      >
+        {items.map(({ label, onClick }) => (
+          <button
+            key={label}
+            className={twMerge(
+              'flex justify-center items-center w-full h-[38px] body-m cursor-pointer transition-all whitespace-nowrap px-5 hover:bg-secondary-1 hover:text-primary-active',
+            )}
+            onClick={onClick}
+          >
+            {label}
+          </button>
+        ))}
+      </motion.div>
   );
 }

--- a/src/components/YouTubeAudioPlayer.tsx
+++ b/src/components/YouTubeAudioPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 // import YouTube from 'react-youtube';
 import { useYouTubeStore } from '@/store/youtubeStore';
+import { createPortal } from 'react-dom';
 // import { twMerge } from 'tailwind-merge';
 
 // YouTube Player Props 정의
@@ -67,7 +68,7 @@ const YouTubeAudioPlayer: React.FC<YouTubeAudioPlayerProps> = ({ playerId }) => 
       playerElement.style.top = '0px';
     }
   }, []);
-  return <div id={`player-${playerId}`}></div>;
+  return createPortal(<div id={`player-${playerId}`}></div>, document.body);
 };
 
 export default YouTubeAudioPlayer;

--- a/src/components/loading/Complete.tsx
+++ b/src/components/loading/Complete.tsx
@@ -1,0 +1,21 @@
+import { motion } from 'framer-motion';
+
+export default function Complete() {
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-6 h-6"
+      initial={{ strokeDasharray: '30 30', strokeDashoffset: 30 }}
+      animate={{ strokeDashoffset: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+    >
+      <motion.path d="M5 12l5 5L19 7" />
+    </motion.svg>
+  );
+}

--- a/src/components/loading/Error.tsx
+++ b/src/components/loading/Error.tsx
@@ -1,0 +1,18 @@
+import { motion } from 'framer-motion';
+
+export default function Error() {
+  return (
+    <motion.div
+      className="text-xl"
+      animate={{
+        x: ['-5px', '5px', '-5px', '5px', '0px'],
+      }}
+      transition={{
+        duration: 0.4,
+        ease: 'easeInOut',
+      }}
+    >
+      !
+    </motion.div>
+  );
+}

--- a/src/components/loading/ErrorShake.tsx
+++ b/src/components/loading/ErrorShake.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 
-export default function Error() {
+export default function ErrorShake() {
   return (
     <motion.div
       className="text-xl"

--- a/src/components/loading/SpinLoading.tsx
+++ b/src/components/loading/SpinLoading.tsx
@@ -1,0 +1,5 @@
+export default function SpinLoading() {
+  return (
+    <div className="w-5 h-5 border-2 border-white border-b-transparent rounded-full animate-spin"></div>
+  );
+}

--- a/src/components/modalSheet/CardDetailModal.tsx
+++ b/src/components/modalSheet/CardDetailModal.tsx
@@ -60,6 +60,19 @@ function CardDetailModal({
     getVideoId();
   }, [data]);
 
+  //sheet open 시 스크롤 제거
+  useEffect(() => {
+    if (isCardSheetOpen) {
+      document.body.style.overflow = 'hidden'; // 스크롤 막기
+    } else {
+      document.body.style.overflow = 'auto'; // 스크롤 복원
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [isCardSheetOpen]);
+
   if (!isCardSheetOpen) {
     return null;
   }

--- a/src/components/testLogin/TestLoginModal.tsx
+++ b/src/components/testLogin/TestLoginModal.tsx
@@ -53,7 +53,7 @@ export default function TestLoginModal() {
   const { isAuthenticated } = useAuthStore();
 
   return (
-    <div className="fixed top-0 left-0 z-50">
+    <div className="fixed top-0 left-0 z-9999">
       {isAuthenticated ? (
         <>
           <button

--- a/src/components/testLogin/TestLoginModal.tsx
+++ b/src/components/testLogin/TestLoginModal.tsx
@@ -53,7 +53,7 @@ export default function TestLoginModal() {
   const { isAuthenticated } = useAuthStore();
 
   return (
-    <div className="fixed top-0 left-0 z-9999">
+    <div className="fixed top-0 left-0 z-60">
       {isAuthenticated ? (
         <>
           <button

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -56,7 +56,7 @@ function Layout() {
       <div
         className={twMerge(
           'pt-[44px] flex-1 flex justify-center w-full px-3',
-          showNav && 'pb-[62px] ', // 하단 네비게이션 숨길때만 padding주기
+          // showNav && 'pb-[62px] ', // 하단 네비게이션 숨길때만 padding주기
         )}
       >
         <Outlet />

--- a/src/layouts/ModalSheetLayout.tsx
+++ b/src/layouts/ModalSheetLayout.tsx
@@ -51,9 +51,9 @@ function ModalSheetLayout({
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center scroll">
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
       <motion.div
-        className="max-w-[600px] w-full h-screen flex flex-col bg-white rounded-[8px] card-shadow border border-gray-5 overflow-y-auto"
+        className="max-w-[600px] w-full h-screen flex flex-col bg-white rounded-[8px] card-shadow border border-gray-5 overflow-y-auto scroll"
         initial="hidden"
         animate="visible"
         variants={modalVariants}

--- a/src/layouts/ModalSheetLayout.tsx
+++ b/src/layouts/ModalSheetLayout.tsx
@@ -51,7 +51,7 @@ function ModalSheetLayout({
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center scroll">
       <motion.div
         className="max-w-[600px] w-full h-screen flex flex-col bg-white rounded-[8px] card-shadow border border-gray-5 overflow-y-auto"
         initial="hidden"

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,8 +6,11 @@ import kakao from '@assets/icons/kakao-icon.svg';
 import Input from '@/components/Input';
 import { useState } from 'react';
 import { useModalStore } from '@/store/modalStore';
+import SpinLoading from '@/components/loading/SpinLoading';
 
 export default function Login() {
+  const [isLoading, setIsLoading] = useState(false);
+
   const { openModal, closeModal } = useModalStore();
   const navigate = useNavigate();
 
@@ -55,14 +58,23 @@ export default function Login() {
     }
 
     try {
+      setIsLoading(true);
       const { code, data } = await login(trimmedId, trimmedPassword);
       navigate('/home');
       console.log('로그인 됨', code, data.accessToken);
     } catch (error) {
       handleLoginFailModal('아이디와 비밀번호를 다시 확인해 주세요.'); // 로그인 실패 모달
       console.log('로그인 에러', error);
+    } finally {
+      setIsLoading(false);
     }
     resetInputs();
+  };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>로그인</span>;
   };
 
   return (
@@ -102,7 +114,7 @@ export default function Login() {
             />
           </div>
         </div>
-        <Button className="focus:outline-primary-active mt-[14px]">로그인</Button>
+        <Button className="focus:outline-primary-active mt-[14px]">{renderButtonContent()}</Button>
       </form>
 
       <div className="flex flex-col gap-3 items-center w-full mt-2.5 ">

--- a/src/pages/editprofile/EditProfile.tsx
+++ b/src/pages/editprofile/EditProfile.tsx
@@ -13,8 +13,8 @@ import { useNavigate } from 'react-router';
 import { useModalStore } from '@/store/modalStore';
 import SpinLoading from '@/components/loading/SpinLoading';
 import Complete from '@/components/loading/Complete';
-import Error from '@/components/loading/Error';
 import { twMerge } from 'tailwind-merge';
+import ErrorShake from '@/components/loading/ErrorShake';
 
 type ValidationMessage = {
   type: 'success' | 'error' | '';
@@ -167,6 +167,8 @@ function EditProfile() {
             navigate('/mypage');
           },
         });
+      } else {
+        throw new Error();
       }
     } catch (error) {
       setIsError(true);
@@ -232,7 +234,7 @@ function EditProfile() {
     } else if (isComplete) {
       return <Complete />;
     } else if (isError) {
-      return <Error />;
+      return <ErrorShake />;
     } else return <span>저장하기</span>;
   };
 

--- a/src/pages/editprofile/EditProfile.tsx
+++ b/src/pages/editprofile/EditProfile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Button from '@/components/Button';
 import InputField from '@/components/InputField';
 import MusicCard from '@/components/MusicCard';
@@ -11,6 +11,10 @@ import { useSheetStore } from '@/store/sheetStore';
 import _ from 'lodash';
 import { useNavigate } from 'react-router';
 import { useModalStore } from '@/store/modalStore';
+import SpinLoading from '@/components/loading/SpinLoading';
+import Complete from '@/components/loading/Complete';
+import Error from '@/components/loading/Error';
+import { twMerge } from 'tailwind-merge';
 
 type ValidationMessage = {
   type: 'success' | 'error' | '';
@@ -44,6 +48,10 @@ function EditProfile() {
   const [isMusicSelect, setIsMusicSelect] = useState(false);
   const { closeAllSheets } = useSheetStore();
 
+  const [isLoading, setIsLoading] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [isError, setIsError] = useState(false);
+
   useEffect(() => {
     if (selectedProfileMusic?.spotifyId) {
       setIsMusicSelect(true);
@@ -54,8 +62,8 @@ function EditProfile() {
     }
   }, [selectedProfileMusic]);
 
-  const [prevProfileMusic, setPrevProfileMusic] = useState<ProfileMusic | null>(null);
-  const [prevNickname, setPrevNickname] = useState<string>('');
+  const prevProfileMusic = useRef<ProfileMusic | null>(null);
+  const prevNickname = useRef<string>('');
   const [currentPassword, setCurrentPassword] = useState<string>('');
 
   const [nickname, setNickname] = useState('');
@@ -89,15 +97,15 @@ function EditProfile() {
         passwordConfirm: { type: '', message: '' },
       }));
     } else {
-      setNickname(prevNickname);
-      selectProfileMusic(prevProfileMusic);
+      setNickname(prevNickname.current);
+      selectProfileMusic(prevProfileMusic.current);
     }
   }, [activeTab]);
 
   //노래 이전과 달라진게 없으면 disable
-  const isProfileMusicSame = _.isEqual(prevProfileMusic, selectedProfileMusic);
+  const isProfileMusicSame = _.isEqual(prevProfileMusic.current, selectedProfileMusic);
   //닉네임 바뀌지 않거나, 바뀌었는데 중복확인이 안되었으면 disable
-  const isNicknameSame = _.isEqual(prevNickname, nickname);
+  const isNicknameSame = _.isEqual(prevNickname.current, nickname);
   const isNicknameValid = validationMessages.nickname?.type === 'success';
 
   //disable 조건
@@ -129,66 +137,111 @@ function EditProfile() {
   };
 
   const handleProfileSubmit = async () => {
-    //업데이트 된 것만 전송
-    const updatedData: Partial<ProfileFormType> = {};
-    if (nickname !== prevNickname) {
-      updatedData.nickName = nickname;
-    }
-    if (selectedProfileMusic !== prevProfileMusic) {
-      updatedData.spotifyId = selectedProfileMusic?.spotifyId;
-      updatedData.title = selectedProfileMusic?.title;
-      updatedData.artist = selectedProfileMusic?.artist;
-      updatedData.albumImage = selectedProfileMusic?.album;
-    }
-    console.log(updatedData);
+    try {
+      setIsLoading(true);
+      // 업데이트 된 것만 전송
+      const updatedData: Partial<ProfileFormType> = {};
+      if (nickname !== prevNickname.current) {
+        updatedData.nickName = nickname;
+      }
+      if (selectedProfileMusic !== prevProfileMusic.current) {
+        updatedData.spotifyId = selectedProfileMusic?.spotifyId;
+        updatedData.title = selectedProfileMusic?.title;
+        updatedData.artist = selectedProfileMusic?.artist;
+        updatedData.albumImage = selectedProfileMusic?.album;
+      }
 
-    const data = await patchEditProfile(updatedData);
+      console.log('전송 데이터:', updatedData);
 
-    console.log(data);
+      // API 호출
+      const data = await patchEditProfile(updatedData);
+      console.log('응답 데이터:', data);
 
-    if (data.code === 200) {
-      //모달 띄우기
+      if (data.code === 200) {
+        setIsComplete(true);
+        openModal({
+          title: '프로필 수정 완료',
+          message: '프로필이 성공적으로 수정되었습니다!',
+          onConfirm: () => {
+            closeModal();
+            navigate('/mypage');
+          },
+        });
+      }
+    } catch (error) {
+      setIsError(true);
+      console.error('프로필 수정 오류:', error);
+
+      // 에러 메시지를 모달로 표시
       openModal({
-        title: '프로필 수정이 완료되었습니다',
+        title: '프로필 수정 실패',
+        message: '잠시 후 다시 시도해주세요.',
         onConfirm: () => {
-          navigate('/mypage');
           closeModal();
+          navigate(-1);
         },
       });
+    } finally {
+      setIsLoading(false);
     }
   };
   const handlePasswordSubmit = async () => {
-    // 현재 비밀번호 1자이상/비밀번호, 비밀번호 확인 맞으면 버튼 활성화
-    //제출 시 우선 현재 비밀번호 확인.
-    const isCurrentPasswordValid = await validateCurrentPassword();
-    if (!isCurrentPasswordValid) {
-      console.log('현재 비밀번호가 일치하지 않습니다.');
-      return;
-    }
-    const updatedData: Partial<ProfileFormType> = {};
-    updatedData.password = formData2.newPassword;
+    try {
+      setIsLoading(true);
 
-    console.log(updatedData);
+      // 현재 비밀번호 확인
+      const isCurrentPasswordValid = await validateCurrentPassword();
+      if (!isCurrentPasswordValid) {
+        console.log('현재 비밀번호가 일치하지 않습니다.');
+        return;
+      }
 
-    const data = await patchEditProfile(updatedData);
-    if (data.code === 200) {
-      //모달 띄우기
+      const updatedData: Partial<ProfileFormType> = {
+        password: formData2.newPassword,
+      };
+
+      // API 호출
+      const data = await patchEditProfile(updatedData);
+
+      if (data.code === 200) {
+        openModal({
+          title: '비밀번호 변경이 완료되었습니다',
+          onConfirm: () => {
+            navigate('/mypage');
+            closeModal();
+          },
+        });
+      }
+    } catch (error) {
+      console.error('비밀번호 변경 오류:', error);
       openModal({
-        title: '비밀번호 수정이 완료되었습니다',
+        title: '비밀번호 변경 실패',
+        message: '잠시 후 다시 시도해주세요.',
         onConfirm: () => {
-          navigate('/mypage');
           closeModal();
+          navigate(-1);
         },
       });
+    } finally {
+      setIsLoading(false);
     }
+  };
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else if (isComplete) {
+      return <Complete />;
+    } else if (isError) {
+      return <Error />;
+    } else return <span>저장하기</span>;
   };
 
   useEffect(() => {
     const loadMyProfile = async () => {
       const data = await getMyProfile();
       console.log(data);
-      setPrevNickname(data.data.nickname);
-      setPrevProfileMusic(data.data.profileMusic);
+      prevNickname.current = data.data.nickname;
+      prevProfileMusic.current = data.data.profileMusic;
 
       setNickname(data.data.nickname);
 
@@ -204,19 +257,26 @@ function EditProfile() {
   return (
     <div className="flex flex-col w-full pt-5 pb-10">
       {/* 탭 메뉴 */}
-      <div className="flex">
+      <div className="relative flex">
         <button
-          className={`p-3 flex-1 ${activeTab === 'profile' ? 'border-b-2 border-primary-active font-bold' : ''}`}
+          className={`p-3 flex-1 ${activeTab === 'profile' ? 'font-bold' : ''}`}
           onClick={() => setActiveTab('profile')}
         >
           프로필 수정
         </button>
         <button
-          className={`p-3 flex-1 ${activeTab === 'password' ? 'border-b-2 border-primary-active font-bold' : ''}`}
+          className={`p-3 flex-1 ${activeTab === 'password' ? 'font-bold' : ''}`}
           onClick={() => setActiveTab('password')}
         >
           비밀번호 변경
         </button>
+        <div
+          className="absolute bottom-0 h-[2px] bg-primary-active transition-all duration-300"
+          style={{
+            width: '50%',
+            left: activeTab === 'profile' ? '0%' : '50%',
+          }}
+        />
       </div>
 
       {/* 폼 */}
@@ -260,9 +320,9 @@ function EditProfile() {
             <Button
               onClick={handleProfileSubmit}
               variant={isProfileDisable ? 'disabled' : 'primary'}
-              className="py-3 body-m mt-5"
+              className={twMerge('py-3 body-m mt-5', isError ? 'bg-functional-danger' : '')}
             >
-              저장하기
+              {renderButtonContent()}
             </Button>
           </>
         ) : (
@@ -309,9 +369,9 @@ function EditProfile() {
             <Button
               onClick={handlePasswordSubmit}
               variant={isPasswordDisable ? 'disabled' : 'primary'}
-              className="py-3 body-m mt-5"
+              className={twMerge('py-3 body-m mt-5', isError ? 'bg-functional-danger' : '')}
             >
-              저장하기
+              {renderButtonContent()}
             </Button>
           </>
         )}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -56,6 +56,7 @@ function Home() {
         return data;
       } catch (error) {
         console.error('감정 기록 불러오기 에러', error);
+        return { records: [], currentPage: 1, totalPages: 1 };
       }
     },
     getNextPageParam: (last) => {
@@ -141,9 +142,6 @@ function Home() {
                       isChatting={true} // 현재 채팅중인지
                     />
                   </div>
-                  {selectedRecordId !== null && (
-                    <CardDetailModal recordId={selectedRecordId} isChatting={true} />
-                  )}
                 </div>
               )),
             )}
@@ -158,6 +156,9 @@ function Home() {
         <div className="flex items-center justify-center w-full h-full mt-[50px]">
           <InfoMessage text="아직 작성된 글이 없어요" />
         </div>
+      )}
+      {selectedRecordId !== null && (
+        <CardDetailModal recordId={selectedRecordId} isChatting={true} />
       )}
       {isLoading && <Loading />}
       {isMusicSheetOpen && <MusicSearchSheet />}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -85,7 +85,7 @@ function Home() {
       setTimeout(() => {
         fetchNextPage();
       }, 1000);
-      fetchNextPage();
+      // fetchNextPage();
     }
   }, [inView, isFetchingNextPage, hasNextPage]);
 
@@ -109,7 +109,7 @@ function Home() {
   }, [searchText]);
 
   return (
-    <div className="flex flex-col w-full gap-5 mt-5 h-fit">
+    <div className="flex flex-col w-full gap-5 mt-5">
       <SearchBar
         searchText={searchText}
         setSearchText={setSearchText}
@@ -124,39 +124,41 @@ function Home() {
         <EmotionFilter onEmotionClick={onEmotionClick} selectedEmotion={selectedEmotion} />
       </div>
       {/* 메인카드 리스트 */}
-      {emotionRecords?.pages[0].records.length > 0 ? (
-        <>
-          <div className="flex flex-col items-center gap-2.5 pb-5">
-            {emotionRecords?.pages.map((page) =>
-              page.records.map((record: EmotionRecord) => (
-                <div className="w-full" key={record.recordId}>
-                  <div onClick={() => handleOpenSheet(record.recordId)}>
-                    <MainCard
-                      albumImage={record.spotifyMusic.albumImage} // 앨범 이미지
-                      nickname={record.nickName} // 닉네임
-                      emotion={record.emotion} // 감정
-                      title={record.spotifyMusic.title} // 노래 제목
-                      artist={record.spotifyMusic.artist} // 가수
-                      comment={record.comment} // 글 내용
-                      createdAt={formatDate(record.createdAt)} // 날짜
-                      isChatting={true} // 현재 채팅중인지
-                    />
+      <div className="h-[calc(100vh-334px-env(safe-area-inset-bottom,16px))] overflow-y-auto">
+        {emotionRecords?.pages[0].records.length > 0 ? (
+          <>
+            <div className="flex flex-col items-center gap-2.5 pb-5 ">
+              {emotionRecords?.pages.map((page) =>
+                page.records.map((record: EmotionRecord) => (
+                  <div className="w-full" key={record.recordId}>
+                    <div onClick={() => handleOpenSheet(record.recordId)}>
+                      <MainCard
+                        albumImage={record.spotifyMusic.albumImage} // 앨범 이미지
+                        nickname={record.nickName} // 닉네임
+                        emotion={record.emotion} // 감정
+                        title={record.spotifyMusic.title} // 노래 제목
+                        artist={record.spotifyMusic.artist} // 가수
+                        comment={record.comment} // 글 내용
+                        createdAt={formatDate(record.createdAt)} // 날짜
+                        isChatting={true} // 현재 채팅중인지
+                      />
+                    </div>
                   </div>
+                )),
+              )}
+              {hasNextPage && !isFetchingNextPage && (
+                <div className="m-auto" ref={ref}>
+                  <LoadingMini />
                 </div>
-              )),
-            )}
-          </div>
-          {hasNextPage && !isFetchingNextPage && (
-            <div className="m-auto" ref={ref}>
-              <LoadingMini />
+              )}
             </div>
-          )}
-        </>
-      ) : (
-        <div className="flex items-center justify-center w-full h-full mt-[50px]">
-          <InfoMessage text="아직 작성된 글이 없어요" />
-        </div>
-      )}
+          </>
+        ) : (
+          <div className="flex items-center justify-center w-full h-full">
+            <InfoMessage text="아직 작성된 글이 없어요" />
+          </div>
+        )}
+      </div>
       {selectedRecordId !== null && (
         <CardDetailModal recordId={selectedRecordId} isChatting={true} />
       )}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -124,7 +124,7 @@ function Home() {
         <EmotionFilter onEmotionClick={onEmotionClick} selectedEmotion={selectedEmotion} />
       </div>
       {/* 메인카드 리스트 */}
-      <div className="h-[calc(100vh-334px-env(safe-area-inset-bottom,16px))] overflow-y-auto">
+      <div className="h-[calc(100vh-334px-env(safe-area-inset-bottom,16px))] overflow-y-auto scroll">
         {emotionRecords?.pages[0].records.length > 0 ? (
           <>
             <div className="flex flex-col items-center gap-2.5 pb-5 ">

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -82,10 +82,10 @@ function Home() {
   useEffect(() => {
     if (inView && !isFetchingNextPage && hasNextPage) {
       //  로딩 시간 추가
-      setTimeout(() => {
-        fetchNextPage();
-      }, 1000);
-      // fetchNextPage();
+      // setTimeout(() => {
+      //   fetchNextPage();
+      // }, 1000);
+      fetchNextPage();
     }
   }, [inView, isFetchingNextPage, hasNextPage]);
 

--- a/src/pages/post/Post.tsx
+++ b/src/pages/post/Post.tsx
@@ -8,6 +8,9 @@ import { postEmotionRecord } from '@/apis/emotionRecord';
 import { useModalStore } from '@/store/modalStore';
 import { useNavigate } from 'react-router';
 import { useMusicCardStore } from '@/store/MusicCardStore';
+import SpinLoading from '@/components/loading/SpinLoading';
+import Complete from '@/components/loading/Complete';
+import Error from '@/components/loading/Error';
 
 export default function Post() {
   const navigate = useNavigate();
@@ -15,6 +18,9 @@ export default function Post() {
   const { selectedPostMusic, clearPostMusic } = useMusicCardStore();
   const { closeAllSheets } = useSheetStore();
 
+  const [isLoading, setIsLoading] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [isError, setIsError] = useState(false);
   //음악 선택 상태 확인
   const [isMusicSelect, setIsMusicSelect] = useState(false);
 
@@ -81,6 +87,8 @@ export default function Post() {
     if (!isCompletePost) return;
 
     try {
+      setIsLoading(true);
+
       const requestData = {
         spotifyId: selectedPostMusic?.spotifyId,
         title: selectedPostMusic?.songTitle,
@@ -94,14 +102,32 @@ export default function Post() {
       // TODO: 로딩 추가
       console.log('기록 완료:', data);
 
+      setIsComplete(true);
       handlePostSuccessModal();
     } catch (error) {
       console.error(error);
+      setIsError(true);
       handlePostFailModal();
     } finally {
-      clearPostMusic();
+      setIsLoading(false);
     }
   };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else if (isComplete) {
+      return <Complete />;
+    } else if (isError) {
+      return <Error />;
+    } else return <span>기록 완료</span>;
+  };
+
+  useEffect(() => {
+    return () => {
+      clearPostMusic();
+    };
+  }, []);
 
   return (
     <div className="flex flex-col items-center justify-between w-full pb-10">
@@ -131,8 +157,12 @@ export default function Post() {
         />
       </div>
       {/* 버튼 */}
-      <Button variant={isCompletePost ? 'primary' : 'disabled'} onClick={onCompletePost}>
-        기록 완료
+      <Button
+        variant={isCompletePost ? 'primary' : 'disabled'} 
+        className={isError ? 'bg-functional-danger' : ''}
+        onClick={onCompletePost}
+      >
+        {renderButtonContent()}
       </Button>
     </div>
   );

--- a/src/pages/post/Post.tsx
+++ b/src/pages/post/Post.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router';
 import { useMusicCardStore } from '@/store/MusicCardStore';
 import SpinLoading from '@/components/loading/SpinLoading';
 import Complete from '@/components/loading/Complete';
-import Error from '@/components/loading/Error';
+import ErrorShake from '@/components/loading/ErrorShake';
 
 export default function Post() {
   const navigate = useNavigate();
@@ -119,7 +119,7 @@ export default function Post() {
     } else if (isComplete) {
       return <Complete />;
     } else if (isError) {
-      return <Error />;
+      return <ErrorShake />;
     } else return <span>기록 완료</span>;
   };
 
@@ -158,7 +158,7 @@ export default function Post() {
       </div>
       {/* 버튼 */}
       <Button
-        variant={isCompletePost ? 'primary' : 'disabled'} 
+        variant={isCompletePost ? 'primary' : 'disabled'}
         className={isError ? 'bg-functional-danger' : ''}
         onClick={onCompletePost}
       >

--- a/src/pages/signup/SignUp.tsx
+++ b/src/pages/signup/SignUp.tsx
@@ -1,5 +1,6 @@
 import { postSignUp } from '@/apis/user';
 import Button from '@/components/Button';
+import SpinLoading from '@/components/loading/SpinLoading';
 import AuthCodeInput from '@/pages/signup/components/AuthCodeInput';
 import EmailInput from '@/pages/signup/components/EmailInput';
 import IdInput from '@/pages/signup/components/IdInput';
@@ -25,6 +26,8 @@ interface ValidationMessages {
 }
 
 function SignUp() {
+  const [isLoading, setIsLoading] = useState(false);
+
   const navigate = useNavigate();
   // 전송할 폼데이터
   const [formData, setFormData] = useState({
@@ -53,6 +56,7 @@ function SignUp() {
   const handleSumbit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
+      setIsLoading(true);
       const { code } = await postSignUp(
         formData.nickname,
         formData.id,
@@ -72,7 +76,15 @@ function SignUp() {
       }
     } catch (error) {
       console.log('회원가입 실패');
+    } finally {
+      setIsLoading(false);
     }
+  };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>지금 시작하기</span>;
   };
 
   return (
@@ -130,7 +142,7 @@ function SignUp() {
           />
         </div>
         <Button variant={allSuccess ? 'primary' : 'disabled'} className="py-[7px] body-m">
-          지금 시작하기
+          {renderButtonContent()}
         </Button>
       </form>
     </div>

--- a/src/pages/signup/components/AuthCodeInput.tsx
+++ b/src/pages/signup/components/AuthCodeInput.tsx
@@ -1,5 +1,6 @@
 import { postEmailVerificationCheck, postEmailVerificationRequest } from '@/apis/email';
 import InputAuthCode from '@/components/InputAuthCode';
+import SpinLoading from '@/components/loading/SpinLoading';
 import { MAX_RESEND_COUNT } from '@/constants/email';
 import { useEffect, useState } from 'react';
 
@@ -20,6 +21,8 @@ interface AuthCodeInputProps {
   setValidation: (validation: ValidationResult) => void;
 }
 function AuthCodeInput({ emailSent, email, setValidation }: AuthCodeInputProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const [authCode, setAuthCode] = useState(''); // 인증코드
   const [resendCount, setResendCount] = useState(0); // 재전송 횟수
   const [buttonVariant, setButtonVariant] = useState<ButtonType>('disabled'); // 버튼 상태를 관리하는 state 추가
@@ -41,6 +44,7 @@ function AuthCodeInput({ emailSent, email, setValidation }: AuthCodeInputProps) 
   // 이메일과 인증코드들 확인하는 함수
   const handleEmailVerificationCheck = async () => {
     try {
+      setIsLoading(true);
       const { code } = await postEmailVerificationCheck(email, authCode);
       if (code === 200) {
         setMessage({ type: 'success', message: '이메일 인증이 완료되었습니다' });
@@ -51,6 +55,8 @@ function AuthCodeInput({ emailSent, email, setValidation }: AuthCodeInputProps) 
       }
     } catch (error) {
       setMessage({ type: 'error', message: '오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' });
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -78,6 +84,13 @@ function AuthCodeInput({ emailSent, email, setValidation }: AuthCodeInputProps) 
       setMessage({ type: 'error', message: '이메일 인증 요청 중 오류가 발생했습니다.' });
     }
   };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>인증확인</span>;
+  };
+
   return (
     <InputAuthCode
       type="text"
@@ -85,7 +98,7 @@ function AuthCodeInput({ emailSent, email, setValidation }: AuthCodeInputProps) 
       label="인증번호 확인"
       placeholder="인증번호 6자리를 입력해 주세요"
       variant={buttonVariant}
-      buttonText="인증확인"
+      buttonText={renderButtonContent()}
       emailSent={emailSent}
       messages={message}
       value={authCode}

--- a/src/pages/signup/components/EmailInput.tsx
+++ b/src/pages/signup/components/EmailInput.tsx
@@ -1,5 +1,6 @@
 import { getEmailAvailability, postEmailVerificationRequest } from '@/apis/email';
 import InputField from '@/components/InputField';
+import SpinLoading from '@/components/loading/SpinLoading';
 import { EMAIL_REGEX } from '@/constants';
 import React, { useEffect, useState } from 'react';
 
@@ -17,6 +18,7 @@ interface EmailInputProps {
 }
 
 function EmailInput({ value, setValue, validation, setValidation, onSendEmail }: EmailInputProps) {
+  const [isLoading, setIsLoading] = useState(false);
   // 버튼 상태를 관리하는 state 추가
   const [buttonVariant, setButtonVariant] = useState<'primary' | 'secondary' | 'disabled'>(
     'primary',
@@ -44,6 +46,7 @@ function EmailInput({ value, setValue, validation, setValidation, onSendEmail }:
   // 이메일 중복을 확인하는 함수
   const handleEmailCheck = async () => {
     try {
+      setIsLoading(true);
       const { code } = await getEmailAvailability(value);
       if (code === 200) {
         handlePostEmailVerificationRequest(); // 사용 가능한 이메일 경우에만 이메일 인증 요청 보내기
@@ -55,6 +58,8 @@ function EmailInput({ value, setValue, validation, setValidation, onSendEmail }:
       }
     } catch (error) {
       setValidation({ type: 'error', message: '예기치 않은 오류가 발생했습니다' });
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -77,6 +82,12 @@ function EmailInput({ value, setValue, validation, setValidation, onSendEmail }:
     }
   };
 
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>인증요청</span>;
+  };
+
   // value나 validation 상태가 변경될 때마다 버튼 상태 업데이트
   useEffect(() => {
     if (value === '' || validation.type === 'error') {
@@ -95,7 +106,7 @@ function EmailInput({ value, setValue, validation, setValidation, onSendEmail }:
       label="이메일 인증"
       placeholder="이메일을 입력해 주세요"
       variant={buttonVariant}
-      buttonText="인증요청"
+      buttonText={renderButtonContent()}
       value={value}
       onChange={handleChange}
       validationMessages={validation}

--- a/src/pages/signup/components/IdInput.tsx
+++ b/src/pages/signup/components/IdInput.tsx
@@ -1,5 +1,6 @@
 import { getIdAvailability } from '@/apis/user';
 import InputField from '@/components/InputField';
+import SpinLoading from '@/components/loading/SpinLoading';
 import { ID_REGEX } from '@/constants';
 import React, { useEffect, useState } from 'react';
 
@@ -17,6 +18,8 @@ interface IdInputProps {
 }
 
 function IdInput({ value, setValue, validation, setValidation }: IdInputProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const [buttonVariant, setButtonVariant] = useState<ButtonType>('disabled'); // 버튼 상태를 관리하는 state 추가
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
@@ -47,6 +50,7 @@ function IdInput({ value, setValue, validation, setValidation }: IdInputProps) {
   // 아이디 중복을 확인하는 함수
   const handleIdCheck = async () => {
     try {
+      setIsLoading(true);
       const { code } = await getIdAvailability(value);
       if (code === 200) {
         setValidation({ type: 'success', message: '사용 가능한 아이디입니다' });
@@ -55,8 +59,17 @@ function IdInput({ value, setValue, validation, setValidation }: IdInputProps) {
       }
     } catch (error) {
       setValidation({ type: 'error', message: '예기치 않은 오류가 발생했습니다' });
+    } finally {
+      setIsLoading(false);
     }
   };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>중복확인</span>;
+  };
+
   return (
     <InputField
       type="text"
@@ -64,7 +77,7 @@ function IdInput({ value, setValue, validation, setValidation }: IdInputProps) {
       label="아이디"
       placeholder="아이디를 입력해 주세요"
       variant={buttonVariant}
-      buttonText="중복확인"
+      buttonText={renderButtonContent()}
       value={value}
       onChange={handleChange}
       validationMessages={validation}

--- a/src/pages/signup/components/NicknameInput.tsx
+++ b/src/pages/signup/components/NicknameInput.tsx
@@ -1,6 +1,8 @@
 import { getNicknameAvailability } from '@/apis/user';
 import InputField from '@/components/InputField';
+import SpinLoading from '@/components/loading/SpinLoading';
 import { NICKNAME_REGEX } from '@/constants';
+import { useState } from 'react';
 
 interface ValidationResult {
   type: 'success' | 'error' | ''; // 유효성 검사 결과 타입
@@ -15,6 +17,8 @@ interface NicknameInputProps {
 }
 
 function NicknameInput({ value, setValue, validation, setValidation }: NicknameInputProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
     setValue(newValue);
@@ -45,6 +49,7 @@ function NicknameInput({ value, setValue, validation, setValidation }: NicknameI
   // 닉네임 중복을 확인하는 함수
   const handleNicknameCheck = async () => {
     try {
+      setIsLoading(true);
       const { code } = await getNicknameAvailability(value);
       if (code === 200) {
         setValidation({ type: 'success', message: '사용 가능한 닉네임입니다' });
@@ -53,7 +58,15 @@ function NicknameInput({ value, setValue, validation, setValidation }: NicknameI
       }
     } catch (error) {
       setValidation({ type: 'error', message: '예기치 않은 오류가 발생했습니다' });
+    } finally {
+      setIsLoading(false);
     }
+  };
+
+  const renderButtonContent = () => {
+    if (isLoading) {
+      return <SpinLoading />;
+    } else return <span>중복확인</span>;
   };
 
   return (
@@ -63,7 +76,7 @@ function NicknameInput({ value, setValue, validation, setValidation }: NicknameI
       label="닉네임"
       placeholder="닉네임을 입력해 주세요"
       variant={value === '' || validation.type === 'error' ? 'disabled' : 'primary'}
-      buttonText="중복확인"
+      buttonText={renderButtonContent()}
       value={value}
       onChange={handleChange}
       validationMessages={validation}

--- a/src/pages/userprofile/UserProfile.tsx
+++ b/src/pages/userprofile/UserProfile.tsx
@@ -139,8 +139,8 @@ function UserProfile({ isMyPage }: { isMyPage: boolean }) {
   }, [inView]);
 
   return (
-    <>
-      <div className="flex flex-col items-center w-full gap-4 py-4">
+    <div className="w-full h-[calc(100vh-112px-env(safe-area-inset-bottom,16px))] overflow-y-auto noScroll">
+      <div className="flex flex-col items-center w-full h-full gap-4 py-4">
         <div className="flex flex-col items-center">
           <span className="h3-b">{userData?.data?.nickname}</span>
           <span className="caption-m text-gray-60">@{userData?.data?.loginId}</span>
@@ -155,7 +155,7 @@ function UserProfile({ isMyPage }: { isMyPage: boolean }) {
         {emotionRecords?.pages[0].data.records.length > 0 ? (
           //   기본으로 2열이다가 크기가 500px가 넘어가면 3열로 변경
           <>
-            <div className="grid grid-cols-2 min-[500px]:grid-cols-3 gap-x-3 gap-y-6">
+            <div className="grid grid-cols-2 min-[500px]:grid-cols-3 gap-x-3 gap-y-6 pb-4">
               {emotionRecords?.pages.map((page) =>
                 page.data.records.map((record: EmotionRecord) => (
                   <EmotionRecordCard
@@ -169,12 +169,12 @@ function UserProfile({ isMyPage }: { isMyPage: boolean }) {
                   />
                 )),
               )}
+              {hasNextPage && !isFetchingNextPage && (
+                <div className="border border-blue-500" ref={ref}>
+                  <LoadingMini />
+                </div>
+              )}
             </div>
-            {hasNextPage && !isFetchingNextPage && (
-              <div className="border border-blue-500" ref={ref}>
-                <LoadingMini />
-              </div>
-            )}
           </>
         ) : (
           <div className="flex items-center justify-center w-full h-full">
@@ -189,7 +189,7 @@ function UserProfile({ isMyPage }: { isMyPage: boolean }) {
           handleDelete={handleDeleteModal}
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,5 +4,6 @@
 @import '@styles/scrollbar.css';
 
 body{
-    overflow-y: hidden;
+    overflow-x: hidden;
+    
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,3 +2,7 @@
 @import '@styles/fonts.css';
 @import '@styles/typography.css';
 @import '@styles/scrollbar.css';
+
+body{
+    overflow-y: hidden;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,7 +3,7 @@
 @import '@styles/typography.css';
 @import '@styles/scrollbar.css';
 
-body{
-    overflow: hidden;
-    
+body {
+  overflow-x: hidden;
+  overflow-y: hidden;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,6 +4,6 @@
 @import '@styles/scrollbar.css';
 
 body{
-    overflow-x: hidden;
+    overflow: hidden;
     
 }

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -14,3 +14,7 @@
 .scroll::-webkit-scrollbar-track {
   background-color: rgba(0, 0, 0, 0); /* 투명 */
 }
+
+.noScroll::-webkit-scrollbar {
+  display: none;
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -42,6 +42,18 @@
       transform: translateX(calc(-1 * var(--move-distance)));
     }
   }
+
+  @keyframes draw {
+    0% {
+      stroke-dasharray: 0, 30;
+      stroke-dashoffset: 30;
+    }
+    100% {
+      stroke-dasharray: 30, 30;
+      stroke-dashoffset: 0;
+    }
+  }
+  
 }
 @layer utilities {
   .bg-background {


### PR DESCRIPTION
## #️⃣연관된 이슈
## 📝작업 내용

> 회원가입 버튼, 로그인 버튼, 포스팅 버튼, 프로필 수정 완료 버튼에 로딩 추가
셀렉트박스, 페이지 이동에 애니메이션 추가
(AnumatePresence  App.tsx에 추가, 화면 absolute 로 해서 다음 애니메이션과 exit 애니메이션이 겹쳐보일 수 있도록)
글작성, 프로필수정 성공, 실패시 버튼 변경
모달, 시트 오픈 시 body 스크롤 제거
유튜브 영상 컴포넌트 portal로 body로 이동
모달 overlay 클릭 시 닫히지 않도록 수정



이슈
+ 로그인 화면에서 엔터로 폼 제출하면 모달 열린 상태에서 입력하고 제출할 수 있는 문제


## 📸 스크린샷


## 💬리뷰 요구사항(선택)
