### PR TITLE
[feat] 스포티파이 ID로 비디오 ID 조회 기능 추가

### DIFF
--- a/src/apis/emotionRecord.ts
+++ b/src/apis/emotionRecord.ts
@@ -22,6 +22,14 @@ export const postEmotionRecord = async (emotionRecord: EmotionRecordRequest) => 
   return data;
 };
 
+// spotifyId로 videoId 조회
+export const getSpotifyVideoId = async (spotifyId: string) => {
+  const { data } = await axiosInstance.get(`/emotion/spotify-video`, {
+    params: { spotifyId },
+  });
+  return data;
+};
+
 // 감정 기록 수정
 export const putEmotionRecord = async (recordId: number, emotionRecord: EmotionRecordRequest) => {
   const { data } = await axiosInstance.put(`/emotion/${recordId}`, emotionRecord);

--- a/src/pages/post/Post.tsx
+++ b/src/pages/post/Post.tsx
@@ -119,8 +119,6 @@ export default function Post() {
 
   // spotifyId로 videoId 조회
   const fetchSpotifyVideoId = async (spotifyId: string, artist: string, title: string) => {
-    console.log('videoId 조회 시작 스포티파이아이디:', spotifyId);
-
     try {
       const data = await getSpotifyVideoId(spotifyId); // 서버에 videoId 조회
       console.log('videoId 조회 결과:', data);
@@ -149,7 +147,6 @@ export default function Post() {
       selectedPostMusic?.artistName,
       selectedPostMusic?.songTitle,
     );
-    console.log('videoId:', videoId);
 
     try {
       setIsLoading(true);

--- a/src/pages/post/Post.tsx
+++ b/src/pages/post/Post.tsx
@@ -4,13 +4,19 @@ import MusicCard from '@/components/MusicCard';
 import Comment from '@/pages/post/components/Comment';
 import { useEffect, useState } from 'react';
 import { useSheetStore } from '@/store/sheetStore';
-import { getEmotionRecordById, postEmotionRecord, putEmotionRecord } from '@/apis/emotionRecord';
+import {
+  getEmotionRecordById,
+  getSpotifyVideoId,
+  postEmotionRecord,
+  putEmotionRecord,
+} from '@/apis/emotionRecord';
 import { useModalStore } from '@/store/modalStore';
 import { useNavigate, useParams } from 'react-router';
 import { useMusicCardStore } from '@/store/MusicCardStore';
 import SpinLoading from '@/components/loading/SpinLoading';
 import Complete from '@/components/loading/Complete';
 import ErrorShake from '@/components/loading/ErrorShake';
+import { searchYoutubeVideo } from '@/apis/youtube';
 
 export default function Post() {
   const navigate = useNavigate();
@@ -111,15 +117,46 @@ export default function Post() {
     });
   };
 
+  // spotifyId로 videoId 조회
+  const fetchSpotifyVideoId = async (spotifyId: string, artist: string, title: string) => {
+    console.log('videoId 조회 시작 스포티파이아이디:', spotifyId);
+
+    try {
+      const data = await getSpotifyVideoId(spotifyId); // 서버에 videoId 조회
+      console.log('videoId 조회 결과:', data);
+
+      // 서버에 videoId 가 있으면
+      if (data.code === 200 && data.data) return data.videoId;
+      // 서버에 videoId 가 없으면
+      else {
+        // youtube 검색
+        const videoId = await searchYoutubeVideo(`${artist} - ${title} lyrics`);
+        console.log('유튜브 videoId:', videoId);
+        return videoId;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   // 기록 완료
   const onCompletePost = async () => {
     if (!isCompletePost) return;
+
+    // 음악 선택 시 videoId 조회
+    const videoId = await fetchSpotifyVideoId(
+      selectedPostMusic?.spotifyId,
+      selectedPostMusic?.artistName,
+      selectedPostMusic?.songTitle,
+    );
+    console.log('videoId:', videoId);
 
     try {
       setIsLoading(true);
 
       const requestData = {
         spotifyId: selectedPostMusic?.spotifyId,
+        videoId: videoId,
         title: selectedPostMusic?.songTitle,
         artist: selectedPostMusic?.artistName,
         albumImage: selectedPostMusic?.albumImage,
@@ -136,6 +173,7 @@ export default function Post() {
         data = await postEmotionRecord(requestData);
       }
       console.log(isEditMode ? '수정 완료' : '기록 완료:', data);
+      console.log('요청 데이터:', requestData);
 
       setIsComplete(true);
       handlePostSuccessModal();


### PR DESCRIPTION
## #️⃣연관된 이슈
- #179 

## 📝작업 내용
글 작성시 videoId 전달 기능 추가
fetchSpotifyVideoId 함수 추가: Spotify ID로 videoId 조회
> 서버에서 videoId를 조회한 후, 존재하지 않으면 YouTube에서 검색하여 가져오도록 처리
- onCompletePost에서 해당 함수(fetchSpotifyVideoId)를 사용하여 videoId를 얻고 기록에 반영

## 📸 스크린샷

## 💬리뷰 요구사항(선택)
