### PR TITLE
[fix] 프로필 뮤직 삭제 로직 수정

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -5,7 +5,7 @@ interface UserProfileEdit {
   loginId: string;
   password: string;
   nickName: string;
-  spotifyId: string;
+  spotifyId: string | -1;
   title: string;
   artist: string;
   albumImage: string;

--- a/src/components/MusicCard.tsx
+++ b/src/components/MusicCard.tsx
@@ -119,6 +119,7 @@ export default function MusicCard({
           </div>
           {rightElement === 'button' && (
             <Button
+              type="button"
               onClick={() => openSheet('isMusicSheetOpen')}
               variant={buttonType}
               className="w-[51px] h-[32px] flex-shrink-0"

--- a/src/pages/editprofile/components/ProfileEditForm.tsx
+++ b/src/pages/editprofile/components/ProfileEditForm.tsx
@@ -16,7 +16,7 @@ import { twMerge } from 'tailwind-merge';
 type ProfileFormType = {
   password: string;
   nickName: string;
-  spotifyId: string;
+  spotifyId: string | -1;
   title: string;
   artist: string;
   albumImage: string;
@@ -52,11 +52,19 @@ function ProfileEditForm() {
       if (nickname !== prevNickname.current) {
         updatedData.nickName = nickname;
       }
+      // 현재 프로필 뮤직이랑 이전 프로필 뮤직이 다를때만 업데이트
       if (selectedProfileMusic !== prevProfileMusic.current) {
-        updatedData.spotifyId = selectedProfileMusic?.spotifyId;
-        updatedData.title = selectedProfileMusic?.title;
-        updatedData.artist = selectedProfileMusic?.artist;
-        updatedData.albumImage = selectedProfileMusic?.album;
+        // 프로필 뮤직이 선택되어있을 경우
+        if (selectedProfileMusic) {
+          updatedData.spotifyId = selectedProfileMusic.spotifyId;
+          updatedData.title = selectedProfileMusic.title;
+          updatedData.artist = selectedProfileMusic.artist;
+          updatedData.albumImage = selectedProfileMusic.album;
+        }
+        // 프로필 뮤직이 선택되지않아서 삭제하는 로직
+        else {
+          updatedData.spotifyId = -1;
+        }
       }
 
       console.log('전송 데이터:', updatedData);
@@ -121,12 +129,14 @@ function ProfileEditForm() {
 
   useEffect(() => {
     const loadMyProfile = async () => {
-      const data = await getMyProfile();
-      prevNickname.current = data.data.nickname; // 이전 닉네임 저장하기
-      prevProfileMusic.current = data.data.profileMusic; // 이전 음악 저장하기
+      const { data } = await getMyProfile();
+      const { nickname, profileMusic } = data;
 
-      setNickname(data.data.nickname);
-      selectProfileMusic(data.data.profileMusic);
+      prevNickname.current = nickname; // 이전 닉네임 저장
+      prevProfileMusic.current = profileMusic?.spotifyId ? profileMusic : null; // 이전 음악저장
+
+      setNickname(nickname);
+      selectProfileMusic(prevProfileMusic.current);
     };
     loadMyProfile();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #199 

## 📝작업 내용
1. 스포티파이ID도 -1의 값을 넣어야하기 때문에 타입 추가했습니다.
2. 프로필 뮤직 삭제 가능하게 수정하고, 기존 삭제를 눌럿을 시 폼 제출되는 문제 수정하였습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/124dc34f-bf10-4c49-93a2-e8b8b424d058


## 💬리뷰 요구사항(선택)
