### PR TITLE
[refacto]: 텍스트 압축 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
         "vite": "^6.1.0",
+        "vite-plugin-compression": "^0.5.1",
         "vite-plugin-pwa": "^0.21.1"
       }
     },
@@ -8263,6 +8264,36 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-compression": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+      "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.0.0"
+      }
+    },
+    "node_modules/vite-plugin-compression/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vite-plugin-pwa": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",
     "vite": "^6.1.0",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-pwa": "^0.21.1"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath, URL } from 'url';
+import compression from 'vite-plugin-compression';
 
 // https://vite.dev/config/
 
@@ -15,6 +16,16 @@ export default defineConfig(({ mode }) => {
       global: 'window', // global을 window로 설정
     },
     plugins: [
+      compression({
+        algorithm: 'brotliCompress', // Brotli 적용
+        threshold: 1024, // 1KB 이상만 압축
+        ext: '.br', // Brotli 확장자 사용
+      }),
+      compression({
+        algorithm: 'gzip', // Gzip도 적용 (백업용)
+        threshold: 1024, // 1KB 이상만 압축
+        ext: '.gz',
+      }),
       react(),
       tailwindcss(),
       VitePWA({


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #263 

## 📝작업 내용
vite-plugin-compression 플러그인을 추가하여 gzip 및 brotli 압축적용하였습니다.

## 📸 스크린샷
<img width="544" alt="image" src="https://github.com/user-attachments/assets/aa3edbd7-96c3-4a35-8266-10e406695584" />


## 💬리뷰 요구사항(선택)
