### PR TITLE
[feat] scrollLock state 전달하여 스크롤 이동 제어

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -2,9 +2,11 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router';
 
 function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, state } = useLocation();
 
   useEffect(() => {
+    if (state?.scrollLock) return; // scrollLock이 true면 스크롤 안 함
+
     window.scrollTo({
       top: 0,
     });

--- a/src/components/modalSheet/BackLink.tsx
+++ b/src/components/modalSheet/BackLink.tsx
@@ -7,7 +7,11 @@ const BackLink = () => {
   pathSegments.pop(); // 마지막 세그먼트 제거
   const newPath = '/' + pathSegments.join('/');
   return (
-    <Link to={newPath} className="flex items-center justify-center w-6 h-6 cursor-pointer">
+    <Link
+      to={newPath}
+      state={{ scrollLock: true }}
+      className="flex items-center justify-center w-6 h-6 cursor-pointer"
+    >
       <img src={closeIcon} alt="닫기" />
     </Link>
   );

--- a/src/components/user/EmotionRecordCardList.tsx
+++ b/src/components/user/EmotionRecordCardList.tsx
@@ -21,7 +21,11 @@ function EmotionRecordCardList({ records, basePath }: EmotionRecordCardListProps
         <EmotionRecordCard
           key={record.recordId}
           record={record}
-          onClick={() => navigate(`${basePath}/${record.recordId}`)}
+          onClick={() =>
+            navigate(`${basePath}/${record.recordId}`, {
+              state: { scrollLock: true },
+            })
+          }
         />
       ))}
     </div>

--- a/src/layouts/bottomNav/BottomNav.tsx
+++ b/src/layouts/bottomNav/BottomNav.tsx
@@ -43,7 +43,7 @@ export default function BottomNav() {
     //메인 페이지
     location.pathname === '/home' ||
     //마이 페이지
-    location.pathname === '/mypage' ||
+    location.pathname.startsWith('/mypage') ||
     //유저 페이지
     location.pathname.startsWith('/user') ||
     //지난 대화 기록 페이지


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- BackLink 클릭 시 state에 scrollLock: true 전달
- EmotionRecordCardList에서 navigate 시 scrollLock: true 전달
- ScrollToTop 컴포넌트에서 state.scrollLock이 true일 경우 window.scrollTo 생략
- BottomNav에서 /mypage 하위 경로까지 인식하도록 조건 수정


## 📸 스크린샷

## 💬리뷰 요구사항(선택)
