### PR TITLE
[fix] ImageKitimg 컴포넌트 사이즈 수정

### DIFF
--- a/src/components/ImageKitImg.tsx
+++ b/src/components/ImageKitImg.tsx
@@ -20,7 +20,7 @@ export default function ImageKitImg({
   return (
     <img
       className={className}
-      src={`https://ik.imagekit.io/${import.meta.env.VITE_IMAGEKIT_ID}/${imagePath}?tr=w-${width},h-${height}`}
+      src={`https://ik.imagekit.io/${import.meta.env.VITE_IMAGEKIT_ID}/${imagePath}?tr=w-${width * 2},h-${height * 2}`}
       width={width}
       height={height}
       onError={(e) => {

--- a/src/components/user/EmotionRecordCard.tsx
+++ b/src/components/user/EmotionRecordCard.tsx
@@ -23,8 +23,8 @@ function EmotionRecordCard({ record, onClick }: EmotionRecordCardProps) {
         <EmotionBadge size="small" emotion={emotion} />
         <ImageKitImg
           src={albumImage}
-          height={232}
-          width={232}
+          height={116}
+          width={116}
           className="object-cover w-full rounded-lg aspect-square"
         />
       </div>

--- a/src/pages/home/components/MainCard.tsx
+++ b/src/pages/home/components/MainCard.tsx
@@ -27,8 +27,8 @@ export default function MainCard({ record }: MainCardProps) {
         <div className="flex-shrink-0 w-16 h-16 overflow-hidden rounded-lg">
           <ImageKitImg
             src={record.spotifyMusic.albumImage}
-            width={160}
-            height={160}
+            width={64}
+            height={64}
             className="object-cover w-full h-full"
           />
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
.

## 📝작업 내용
- ImageKitimg 컴포넌트에서 Figma의 디자인 사이즈를 기준으로 이미지를 2배수 크기로 로드하도록 설정

## 📸 스크린샷

## 💬리뷰 요구사항(선택)
